### PR TITLE
[PREVIEW] Feature/sl 1122/rename duration field

### DIFF
--- a/src/app/hearing-part/components/listing-create/listing-create.component.html
+++ b/src/app/hearing-part/components/listing-create/listing-create.component.html
@@ -5,52 +5,59 @@
         </mat-card-header>
 
         <mat-card-content fxLayout="row" fxLayoutGap="5%">
-            <form id="ngForm" #newListForm="ngForm" (ngSubmit)="create();" fxLayout="column" fxLayoutAlign="start stretch" fxLayoutGap="0.5%">
-                <div *ngIf="errors">Error: {{errors}}</div>
+            <form [formGroup]="listingCreate" novalidate (ngSubmit)="create();" id="list-form" fxLayout="column" fxLayoutAlign="start stretch" fxLayoutGap="0.5%">
+                <div class="error" *ngIf="errors">Error: {{errors}}</div>
 
                 <mat-form-field>
-                    <input id="caseNumber" [(ngModel)]="listing.caseNumber" name="caseNumber" matInput placeholder="Case number" type="text" required>
+                    <input id="caseNumber" formControlName="caseNumber" [(ngModel)]="listing.caseNumber" matInput placeholder="Case number *" type="text">
                 </mat-form-field>
 
                 <mat-form-field>
-                    <input id="caseTitle" [(ngModel)]="listing.caseTitle" name="caseTitle" matInput placeholder="Case title" type="text" required>
+                    <input id="caseTitle" formControlName="caseTitle" [(ngModel)]="listing.caseTitle" matInput placeholder="Case title *" type="text" >
                 </mat-form-field>
 
                 <mat-form-field>
-                    <mat-select id="selectCaseType" placeholder="Case type" ngModel name="caseType" [(value)]="listing.caseType" [required]="true">
-                        <mat-option *ngFor="let case of caseTypes" value="{{case}}">{{case}}</mat-option>
+                    <mat-select id="selectCaseType" formControlName="caseType" placeholder="Case type *" [(ngModel)]="listing.caseType">
+                        <mat-option *ngFor="let case of caseTypes" selected="case == caseTypes[0]" [value]="case">{{case}}</mat-option>
                     </mat-select>
                 </mat-form-field>
 
                 <mat-form-field>
-                    <mat-select id="selectHearingPart" placeholder="Hearing type" ngModel name="hearingType" [(value)]="listing.hearingType" required>
-                        <mat-option *ngFor="let hearing of hearings" value="{{hearing}}">{{hearing}}</mat-option>
+                    <mat-select id="selectHearingPart" formControlName="hearingType" placeholder="Hearing type *" [(ngModel)]="listing.hearingType" >
+                        <mat-option *ngFor="let hearing of hearings" selected="hearing == hearings[0]" [value]="hearing">{{hearing}}</mat-option>
                     </mat-select>
                 </mat-form-field>
 
                 <mat-form-field>
-                    <input id="duration" [formControl]="estDurationForm" [(ngModel)]="duration" name="duration" type="number" matInput placeholder="Estimated duration" min="1" required>
+                    <input id="duration" formControlName="duration" [ngModel]="listing.duration | appDurationAsMinutes" (ngModelChange)="updateDuration($event)" type="number" matInput placeholder="Estimated duration *" min="1" >
                     <span matSuffix>Minutes</span>
                 </mat-form-field>
 
                 <mat-form-field>
-                    <input matInput [matDatepicker]="createdAt" [(ngModel)]="listing.createdAt" name="createdAt" placeholder="Created at:">
+                    <input matInput [matDatepicker]="createdAt" formControlName="createdAt" [(ngModel)]="listing.createdAt" placeholder="Created at:">
                     <mat-datepicker-toggle matSuffix [for]="createdAt"></mat-datepicker-toggle>
                     <mat-datepicker #createdAt></mat-datepicker>
                 </mat-form-field>
 
-                <div>Target Schedule <i>(DD/MM/YYYY)</i></div>
-                <mat-form-field class="date-picker-element">
-                    <input id="fromDate" matInput [matDatepicker]="pickerStart" [(ngModel)]="listing.scheduleStart" name="scheduleStart" placeholder="From:" re>
-                    <mat-datepicker-toggle matSuffix [for]="pickerStart"></mat-datepicker-toggle>
-                    <mat-datepicker #pickerStart></mat-datepicker>
-                </mat-form-field>
+                <div formGroupName="targetDates">
+                    <div style="padding-bottom:3px">Target Schedule <i>(DD/MM/YYYY)</i></div>
+                    <div class="error" *ngIf="listingCreate.get('targetDates').hasError('targetFromAfterTargetTo')">
+                        <i>Target from</i> must be before <i>Target to</i>!
+                    </div>
+                    <mat-form-field class="date-picker-element">
+                        <input id="fromDate" matInput [matDatepicker]="pickerStart" formControlName="targetFrom"  [(ngModel)]="listing.scheduleStart" placeholder="From:" re>
+                        <mat-datepicker-toggle matSuffix [for]="pickerStart"></mat-datepicker-toggle>
+                        <mat-datepicker #pickerStart></mat-datepicker>
+                    </mat-form-field>
 
-                <mat-form-field class="date-picker-element">
-                    <input id="endDate" matInput [matDatepicker]="pickerEnd" [(ngModel)]="listing.scheduleEnd" name="scheduleEnd" placeholder="To:">
-                    <mat-datepicker-toggle matSuffix [for]="pickerEnd"></mat-datepicker-toggle>
-                    <mat-datepicker #pickerEnd></mat-datepicker>
-                </mat-form-field>
+                    <mat-form-field class="date-picker-element">
+                        <input id="endDate" matInput [matDatepicker]="pickerEnd" formControlName="targetTo" [(ngModel)]="listing.scheduleEnd" placeholder="To:">
+                        <mat-datepicker-toggle matSuffix [for]="pickerEnd"></mat-datepicker-toggle>
+                        <mat-datepicker #pickerEnd></mat-datepicker>
+                    </mat-form-field>
+                </div>
+
+
             </form>
 
             <div style="padding-right: 2em">
@@ -62,7 +69,7 @@
         </mat-card-content>
 
         <mat-card-actions>
-            <button id="save" mat-raised-button color="accent" fxFlexAlign="right" form="ngForm" [disabled]="isValid(newListForm)">Save</button>
+            <button id="save" mat-raised-button color="accent" form="list-form" fxFlexAlign="right" type="submit" [disabled]="!listingCreate.valid">Save</button>
         </mat-card-actions>
     </mat-card>
 </div>

--- a/src/app/hearing-part/components/listing-create/listing-create.component.html
+++ b/src/app/hearing-part/components/listing-create/listing-create.component.html
@@ -29,7 +29,7 @@
                 </mat-form-field>
 
                 <mat-form-field>
-                    <input id="duration" [(ngModel)]="duration" name="duration" type="number" matInput placeholder="Duration" min="1">
+                    <input id="duration" [formControl]="estDurationForm" [(ngModel)]="duration" name="duration" type="number" matInput placeholder="Estimated duration" min="1" required>
                     <span matSuffix>Minutes</span>
                 </mat-form-field>
 
@@ -41,7 +41,7 @@
 
                 <div>Target Schedule <i>(DD/MM/YYYY)</i></div>
                 <mat-form-field class="date-picker-element">
-                    <input id="fromDate" matInput [matDatepicker]="pickerStart" [(ngModel)]="listing.scheduleStart" name="scheduleStart" placeholder="From:">
+                    <input id="fromDate" matInput [matDatepicker]="pickerStart" [(ngModel)]="listing.scheduleStart" name="scheduleStart" placeholder="From:" re>
                     <mat-datepicker-toggle matSuffix [for]="pickerStart"></mat-datepicker-toggle>
                     <mat-datepicker #pickerStart></mat-datepicker>
                 </mat-form-field>
@@ -62,7 +62,7 @@
         </mat-card-content>
 
         <mat-card-actions>
-            <button id="save" mat-raised-button color="accent" fxFlexAlign="right" form="ngForm" [disabled]="!newListForm.valid">Save</button>
+            <button id="save" mat-raised-button color="accent" fxFlexAlign="right" form="ngForm" [disabled]="isValid(newListForm)">Save</button>
         </mat-card-actions>
     </mat-card>
 </div>

--- a/src/app/hearing-part/components/listing-create/listing-create.component.scss
+++ b/src/app/hearing-part/components/listing-create/listing-create.component.scss
@@ -1,0 +1,5 @@
+.error {
+  font-size: 12px;
+  color: #c7254e;
+  padding-bottom: 3px;
+}

--- a/src/app/hearing-part/components/listing-create/listing-create.component.spec.ts
+++ b/src/app/hearing-part/components/listing-create/listing-create.component.spec.ts
@@ -13,6 +13,7 @@ import { NotesPreparerService } from '../../../notes/services/notes-preparer.ser
 import { ListingCreateNotesConfiguration } from '../../models/listing-create-notes-configuration.model';
 import moment = require('moment');
 import { ListingCreate } from '../../models/listing-create';
+import { DurationAsMinutesPipe } from '../../../core/pipes/duration-as-minutes.pipe';
 
 let storeSpy: jasmine.Spy;
 let component: ListingCreateComponent;
@@ -35,7 +36,7 @@ describe('ListingCreateComponent', () => {
                 StoreModule.forFeature('hearingParts', fromHearingParts.reducers),
                 BrowserAnimationsModule
             ],
-            declarations: [ListingCreateComponent, NoteComponent, NoteListComponent],
+            declarations: [ListingCreateComponent, NoteComponent, NoteListComponent, DurationAsMinutesPipe],
             providers: [NoteListComponent, NotesPreparerService, ListingCreateNotesConfiguration],
         });
 
@@ -132,43 +133,25 @@ describe('ListingCreateComponent', () => {
         expect(createdListing.id).toBeDefined();
     });
 
-    describe('The action should not be sent', () => {
-        it('If start date is after end date', () => {
-            component.listing.scheduleStart = moment().add(1, 'day');
-            component.listing.scheduleEnd = moment();
+      it('If start date is undefined', () => {
+          component.listing.scheduleStart = undefined;
+          component.listing.scheduleEnd = moment();
 
-            expect(component.errors).not.toEqual('Start date should be before End date');
+          component.create();
 
-            component.create();
+          expect(storeSpy).toHaveBeenCalledTimes(1);
+          expect(component.errors).toEqual('');
+      })
 
-            expect(storeSpy).toHaveBeenCalledTimes(0);
-            expect(component.errors).toEqual('Start date should be before End date');
-        })
+      it('If end date is undefined', () => {
+          component.listing.scheduleStart = moment();
+          component.listing.scheduleEnd = undefined;
 
-        it('If start date is undefined', () => {
-            expect(component.errors).not.toEqual('Start date should be before End date');
+          component.create();
 
-            component.listing.scheduleStart = undefined;
-            component.listing.scheduleEnd = moment();
-
-            component.create();
-
-            expect(storeSpy).toHaveBeenCalledTimes(0);
-            expect(component.errors).toEqual('Start date should be before End date');
-        })
-
-        it('If end date is undefined', () => {
-            expect(component.errors).not.toEqual('Start date should be before End date');
-
-            component.listing.scheduleStart = moment();
-            component.listing.scheduleEnd = undefined;
-
-            component.create();
-
-            expect(storeSpy).toHaveBeenCalledTimes(0);
-            expect(component.errors).toEqual('Start date should be before End date');
-        })
-    })
+          expect(storeSpy).toHaveBeenCalledTimes(1);
+          expect(component.errors).toEqual('');
+      })
 
     describe('should prepare notes', () => {
         let createListingAction;

--- a/src/app/hearing-part/components/listing-create/listing-create.component.spec.ts
+++ b/src/app/hearing-part/components/listing-create/listing-create.component.spec.ts
@@ -18,6 +18,7 @@ let storeSpy: jasmine.Spy;
 let component: ListingCreateComponent;
 let store: Store<fromHearingParts.State>;
 let fixture: ComponentFixture<ListingCreateComponent>;
+let listingCreateNoteConfig: ListingCreateNotesConfiguration;
 
 let note;
 let secondNote;
@@ -40,6 +41,7 @@ describe('ListingCreateComponent', () => {
 
         fixture = TestBed.createComponent(ListingCreateComponent);
         component = fixture.componentInstance;
+        listingCreateNoteConfig = TestBed.get(ListingCreateNotesConfiguration);
         store = TestBed.get(Store);
     });
 
@@ -109,6 +111,14 @@ describe('ListingCreateComponent', () => {
 
         expect(createListingAction.type).toEqual(HearingPartActionTypes.CreateListingRequest);
         expect(createListingAction.payload).toEqual(defaultListing);
+    });
+
+      it('with some notes it should set default notes post-creation', () => {
+        component.listing.notes = [{...note, content: 'custom content'}];
+
+        component.create();
+
+        expect(component.listing.notes).toEqual(listingCreateNoteConfig.defaultNotes());
     });
 
     it('should prepare listing request with id', () => {

--- a/src/app/hearing-part/components/listing-create/listing-create.component.ts
+++ b/src/app/hearing-part/components/listing-create/listing-create.component.ts
@@ -71,7 +71,7 @@ export class ListingCreateComponent {
             scheduleStart: now,
             scheduleEnd: moment().add(30, 'day'),
             createdAt: now,
-            notes: this.listingNotesConfig.defaultNotes
+            notes: this.listingNotesConfig.defaultNotes()
         } as ListingCreate;
         this.duration = 30;
         this.errors = '';

--- a/src/app/hearing-part/components/listing-create/listing-create.component.ts
+++ b/src/app/hearing-part/components/listing-create/listing-create.component.ts
@@ -10,6 +10,7 @@ import * as dateUtils from '../../../utils/date-utils';
 import { NoteListComponent } from '../../../notes/components/notes-list/note-list.component';
 import { NotesPreparerService } from '../../../notes/services/notes-preparer.service';
 import { ListingCreateNotesConfiguration } from '../../models/listing-create-notes-configuration.model';
+import { FormControl, NgForm, Validators } from '@angular/forms';
 
 const DURATION_UNIT = 'minute';
 
@@ -20,6 +21,8 @@ const DURATION_UNIT = 'minute';
 })
 export class ListingCreateComponent {
     @ViewChild(NoteListComponent) noteList: NoteListComponent;
+
+    estDurationForm;
 
     hearings: string[];
     caseTypes: string[];
@@ -37,6 +40,8 @@ export class ListingCreateComponent {
         this.store.select(getHearingPartError).subscribe(error => {
             this.errors = error;
         });
+
+        this.estDurationForm = new FormControl('', Validators.min(1));
     }
 
     create() {
@@ -70,5 +75,9 @@ export class ListingCreateComponent {
         } as ListingCreate;
         this.duration = 30;
         this.errors = '';
+    }
+
+    public isValid(form: NgForm) {
+        return !form.valid || !this.estDurationForm.valid
     }
 }

--- a/src/app/hearing-part/components/listing-create/listing-create.component.ts
+++ b/src/app/hearing-part/components/listing-create/listing-create.component.ts
@@ -5,28 +5,26 @@ import { ListingCreate } from '../../models/listing-create';
 import * as moment from 'moment';
 import { v4 as uuid } from 'uuid';
 import { CreateListingRequest } from '../../actions/hearing-part.action';
-import { getHearingPartError } from '../../reducers/hearing-part.reducer';
-import * as dateUtils from '../../../utils/date-utils';
+import { getHearingPartsError } from '../../reducers/index';
 import { NoteListComponent } from '../../../notes/components/notes-list/note-list.component';
 import { NotesPreparerService } from '../../../notes/services/notes-preparer.service';
 import { ListingCreateNotesConfiguration } from '../../models/listing-create-notes-configuration.model';
-import { FormControl, NgForm, Validators } from '@angular/forms';
+import { AbstractControl, FormControl, FormGroup, Validators } from '@angular/forms';
 
 const DURATION_UNIT = 'minute';
 
 @Component({
     selector: 'app-listing-create',
     templateUrl: './listing-create.component.html',
-    styleUrls: []
+    styleUrls: ['./listing-create.component.scss']
 })
 export class ListingCreateComponent {
     @ViewChild(NoteListComponent) noteList: NoteListComponent;
 
-    estDurationForm;
+    listingCreate: FormGroup;
 
-    hearings: string[];
-    caseTypes: string[];
-    duration = 0;
+    hearings: string[] = ['Preliminary Hearing', 'Trial Hearing', 'Adjourned Hearing'];
+    caseTypes: string[] = ['SCLAIMS', 'FTRACK', 'MTRACK'];
     errors = '';
 
     public listing: ListingCreate;
@@ -34,29 +32,42 @@ export class ListingCreateComponent {
     constructor(private readonly store: Store<State>,
                 private notePreparerService: NotesPreparerService,
                 private listingNotesConfig: ListingCreateNotesConfiguration) {
-        this.hearings = ['Preliminary Hearing', 'Trial Hearing', 'Adjourned Hearing'];
-        this.caseTypes = ['SCLAIMS', 'FTRACK', 'MTRACK'];
-        this.initiateListing();
-        this.store.select(getHearingPartError).subscribe(error => {
-            this.errors = error;
+
+        this.store.select(getHearingPartsError).subscribe((error: any) => {
+            this.errors = error.message;
         });
 
-        this.estDurationForm = new FormControl('', Validators.min(1));
+        this.initiateListing();
+        this.initiateForm();
     }
 
     create() {
-        this.listing.id = uuid();
-        this.listing.notes = this.notePreparerService.prepare(this.noteList.getModifiedNotes(),
-            this.listing.id,
-            this.listingNotesConfig.entityName);
+            this.listing.id = uuid();
+            this.listing.notes = this.notePreparerService.prepare(
+                this.noteList.getModifiedNotes(),
+                this.listing.id,
+                this.listingNotesConfig.entityName
+            );
 
-        this.listing.duration.add(this.duration, DURATION_UNIT);
-        if (!dateUtils.isDateRangeValid(this.listing.scheduleStart, this.listing.scheduleEnd)) {
-            this.errors = 'Start date should be before End date';
-        } else {
             this.store.dispatch(new CreateListingRequest(this.listing));
             this.initiateListing();
+    }
+
+    updateDuration(durationValue) {
+        if (durationValue !== undefined && durationValue !== null) {
+            this.listing.duration = moment.duration(durationValue, 'minute')
         }
+    }
+
+    targetDatesValidator(control: AbstractControl): {[key: string]: boolean} {
+        const targetFrom = control.get('targetFrom').value as moment.Moment;
+        const targetTo = control.get('targetTo').value as moment.Moment;
+
+        if (targetFrom === null || targetTo === null) {
+            return null;
+        }
+
+        return targetFrom.isSameOrBefore(targetTo) ? null : { targetFromAfterTargetTo: true };
     }
 
     private initiateListing() {
@@ -67,17 +78,27 @@ export class ListingCreateComponent {
             caseTitle: `title-${now.toISOString()}`,
             caseType: this.caseTypes[0],
             hearingType: this.hearings[0],
-            duration: moment.duration(),
+            duration: moment.duration(30, DURATION_UNIT),
             scheduleStart: now,
             scheduleEnd: moment().add(30, 'day'),
             createdAt: now,
             notes: this.listingNotesConfig.defaultNotes()
         } as ListingCreate;
-        this.duration = 30;
         this.errors = '';
     }
 
-    public isValid(form: NgForm) {
-        return !form.valid || !this.estDurationForm.valid
+    private initiateForm() {
+        this.listingCreate = new FormGroup({
+            caseNumber: new FormControl(this.listing.caseNumber, Validators.required),
+            caseTitle: new FormControl(this.listing.caseTitle, [Validators.required]),
+            caseType: new FormControl(this.listing.caseType, [Validators.required]),
+            hearingType: new FormControl(this.listing.hearingType, [Validators.required]),
+            duration: new FormControl(this.listing.duration.asMinutes(), [Validators.required, Validators.min(1)]),
+            createdAt: new FormControl(this.listing.createdAt),
+            targetDates: new FormGroup({
+                targetFrom: new FormControl(this.listing.scheduleStart),
+                targetTo: new FormControl(this.listing.scheduleEnd),
+            }, this.targetDatesValidator)
+        })
     }
 }

--- a/src/app/hearing-part/hearing-part.module.ts
+++ b/src/app/hearing-part/hearing-part.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ListingCreateComponent } from './components/listing-create/listing-create.component';
 import { AngularMaterialModule } from '../../angular-material/angular-material.module';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { HearingPartsPreviewComponent } from './components/hearing-parts-preview/hearing-parts-preview.component';
 import { StoreModule } from '@ngrx/store';
@@ -27,6 +27,7 @@ export const COMPONENTS = [
   imports: [
     CommonModule,
     AngularMaterialModule,
+    ReactiveFormsModule,
     NotesModule,
     FlexLayoutModule,
     CoreModule,

--- a/src/app/hearing-part/models/listing-create-notes-configuration.model.ts
+++ b/src/app/hearing-part/models/listing-create-notes-configuration.model.ts
@@ -5,14 +5,12 @@ import { Injectable } from '@angular/core';
 @Injectable()
 export class ListingCreateNotesConfiguration implements NotesConfiguration {
     public readonly entityName;
-    public readonly defaultNotes;
 
     constructor() {
         this.entityName = 'ListingRequest';
-        this.defaultNotes = this.defaultListingNotes();
     }
 
-    private defaultListingNotes(): Note[] {
+    public defaultNotes(): Note[] {
         const specReqNote = {
             id: undefined,
             content: '',

--- a/src/app/hearing-part/reducers/index.ts
+++ b/src/app/hearing-part/reducers/index.ts
@@ -30,6 +30,11 @@ export const getHearingPartsLoading = createSelector(
     state => state.loading
 );
 
+export const getHearingPartsError = createSelector(
+    getHearingPartsEntitiesState,
+    state => state.error
+);
+
 export const {
     selectIds: getHearingPartsIds,
     selectEntities: getHearingPartsEntities,

--- a/src/app/notes/components/note/note.component.ts
+++ b/src/app/notes/components/note/note.component.ts
@@ -2,7 +2,6 @@ import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 
 import { NoteViewmodel } from '../../models/note.viewmodel';
 import { FormControl } from '@angular/forms';
-import { debounceTime } from 'rxjs/operators';
 
 @Component({
   selector: 'app-note',
@@ -17,7 +16,6 @@ export class NoteComponent {
 
     constructor() {
         this.content.valueChanges
-            .pipe(debounceTime(300))
             .subscribe( (value) => {
                 this.note.modified = true;
                 this.note.content = value;

--- a/src/app/notes/models/notes-configuration.ts
+++ b/src/app/notes/models/notes-configuration.ts
@@ -2,5 +2,5 @@ import { Note } from './note.model';
 
 export interface NotesConfiguration {
     readonly entityName: string,
-    readonly defaultNotes: Note[]
+    readonly defaultNotes: () => Note[]
 }


### PR DESCRIPTION
Renaming duration field + refactor of the form.

Up to this point the validation of user input happened in two ways: 
1. in the html itself using the built-in validators like 'required'
2. in the 'create' method we checked if the targetFrom and targetTo are properly set

I didn't like that spreading so I went for ReactiveForms from angular. Right now all user input if managed by reactive forms. Concrete controls might have multiple validators used (like the 'Validators.required). Moving to ReactiveForms allows also to group inputs which is helpful for us with inputs: 'targetFrom' and 'targetTo'. Those two are correlated (one must be set after another) and the targetDateValidator validates if they are properly set.

PS. If my previous PR was merged there would be only 6 files changed.