### PR TITLE
SL-1348-SL-1349 Load reference data

### DIFF
--- a/src/app/hearing-part/reducers/hearing-part.reducer.spec.ts
+++ b/src/app/hearing-part/reducers/hearing-part.reducer.spec.ts
@@ -1,0 +1,56 @@
+import { HearingPart } from './../models/hearing-part';
+import { reducer, initialState } from './hearing-part.reducer';
+import { SearchComplete } from '../actions/hearing-part.action';
+import { getHearingParts, State } from './index';
+
+const hearingPartIdA = 'some-id-A';
+const hearingPartA = generateHearingParts(hearingPartIdA);
+const hearingPartIdB = 'some-id-B';
+const hearingPartB = generateHearingParts(hearingPartIdB);
+const hearingParts: HearingPart[] = [
+    hearingPartA,
+    hearingPartB
+];
+let state: State;
+
+describe('HearingPartReducer', () => {
+    describe('Search Complete', () => {
+        beforeEach(() => {
+            state = stateWith(reducer(initialState, new SearchComplete(hearingParts)));
+        });
+
+        it('should add hearing parts to store', () => {
+            expect(Object.keys(getHearingParts(state)).length).toEqual(2);
+            expect(getHearingParts(state)[hearingPartIdA]).toEqual(hearingPartA);
+            expect(getHearingParts(state)[hearingPartIdB]).toEqual(hearingPartB);
+        });
+
+        it('when get empty array should remove saved hearing parts', () => {
+            expect(Object.keys(getHearingParts(state)).length).toEqual(2);
+            state = stateWith(reducer(state.hearingParts.hearingParts, new SearchComplete([])));
+            expect(Object.keys(getHearingParts(state)).length).toEqual(0);
+        });
+    });
+});
+
+function stateWith(hearingPartReducer): State {
+    return { hearingParts: { hearingParts: hearingPartReducer }}
+};
+
+function generateHearingParts(id: string): HearingPart {
+    return {
+        id: id,
+        session: null,
+        caseNumber: null,
+        caseTitle: null,
+        caseType: null,
+        hearingType: null,
+        duration: null,
+        scheduleStart: null,
+        scheduleEnd: null,
+        version: null,
+        priority: null,
+        reservedJudgeId: null,
+        communicationFacilitator: null
+    }
+};

--- a/src/app/judges/reducers/judge.reducer.spec.ts
+++ b/src/app/judges/reducers/judge.reducer.spec.ts
@@ -1,0 +1,43 @@
+import { reducer, initialState } from './judge.reducer';
+import { GetComplete } from '../actions/judge.action';
+import { getJudges, State } from './index';
+import { Judge } from '../models/judge.model';
+
+const judgeIdA = 'some-id-A';
+const judgeA = generateJudge(judgeIdA);
+const judgeIdB = 'some-id-B';
+const judgeB = generateJudge(judgeIdB);
+const judges: Judge[] = [
+    judgeA,
+    judgeB
+];
+let state: State;
+
+describe('JudgeReducer', () => {
+    describe('Get Complete', () => {
+        beforeEach(() => {
+            state = stateWith(reducer(initialState, new GetComplete(judges)));
+        });
+
+        it('should add judges to store', () => {
+            expect(Object.keys(getJudges(state)).length).toEqual(2);
+            expect(getJudges(state)[judgeIdA]).toEqual(judgeA);
+            expect(getJudges(state)[judgeIdB]).toEqual(judgeB);
+        });
+
+        it('when get empty array should remove saved judges', () => {
+            expect(Object.keys(getJudges(state)).length).toEqual(2);
+
+            state = stateWith(reducer(state.judges.judges, new GetComplete([])));
+            expect(Object.keys(getJudges(state)).length).toEqual(0);
+        });
+    });
+});
+
+function stateWith(judgeReducer): State {
+    return { judges: { judges: judgeReducer }};
+};
+
+function generateJudge(id: string): Judge {
+    return { id, name: 'some-judge-name' }
+};

--- a/src/app/judges/reducers/judge.reducer.ts
+++ b/src/app/judges/reducers/judge.reducer.ts
@@ -22,7 +22,7 @@ export function reducer(state: State = initialState, action) {
             return {...state, loading: false, error: action.payload};
         }
         case JudgeActionTypes.GetComplete: {
-            return adapter.addMany( action.payload === undefined ? [] : Object.values(action.payload), {...state, loading: false});
+            return adapter.addAll(action.payload === undefined ? [] : Object.values(action.payload), {...state, loading: false});
         }
         default:
             return state;

--- a/src/app/rooms/reducers/room.reducer.spec.ts
+++ b/src/app/rooms/reducers/room.reducer.spec.ts
@@ -1,0 +1,46 @@
+import { reducer, initialState } from './room.reducer';
+import { GetComplete } from '../actions/room.action';
+import { getRooms } from '.';
+import { State } from '../../sessions/reducers/index'
+import { Room } from '../models/room.model';
+
+const roomIdA = 'some-id-A';
+const roomA = generateRoom(roomIdA);
+const roomIdB = 'some-id-B';
+const roomB = generateRoom(roomIdB);
+const rooms: Room[] = [
+    roomA,
+    roomB
+];
+let state: State;
+
+describe('RoomReducer', () => {
+    describe('Get Complete', () => {
+        beforeEach(() => {
+            state = stateWith(reducer(initialState, new GetComplete(rooms)));
+        });
+
+        it('should add rooms to store', () => {
+            expect(Object.keys(getRooms(state)).length).toEqual(2);
+            expect(getRooms(state)[roomIdA]).toEqual(roomA);
+            expect(getRooms(state)[roomIdB]).toEqual(roomB);
+        });
+
+        it('when get empty array should remove saved rooms', () => {
+            expect(Object.keys(getRooms(state)).length).toEqual(2);
+            state = stateWith(reducer(state.sessions.rooms, new GetComplete([])));
+            expect(Object.keys(getRooms(state)).length).toEqual(0);
+        });
+    });
+});
+
+function stateWith(roomReducer): State {
+    return { sessions: { rooms: roomReducer, sessions: null, sessionTransaction: null }}
+};
+
+function generateRoom(id: string): Room {
+    return {
+        id: id,
+        name: null
+    }
+};

--- a/src/app/sessions/reducers/session.reducer.spec.ts
+++ b/src/app/sessions/reducers/session.reducer.spec.ts
@@ -1,0 +1,53 @@
+import { Session } from './../models/session.model';
+import { reducer, initialState } from './session.reducer';
+import { SearchComplete } from '../actions/session.action';
+import { getSessionEntities } from './index';
+import { State } from './index'
+
+const sessionIdA = 'some-id-A';
+const sessionA = generateSession(sessionIdA);
+const sessionIdB = 'some-id-B';
+const sessionB = generateSession(sessionIdB);
+const sessions: Session[] = [
+    sessionA,
+    sessionB
+];
+let state: State;
+
+describe('SessionReducer', () => {
+    describe('Search Complete', () => {
+        beforeEach(() => {
+            state = stateWith(reducer(initialState, new SearchComplete(sessions)));
+        });
+
+        it('should add sessions to store', () => {
+            expect(Object.keys(getSessionEntities(state)).length).toEqual(2);
+            expect(getSessionEntities(state)[sessionIdA]).toEqual(sessionA);
+            expect(getSessionEntities(state)[sessionIdB]).toEqual(sessionB);
+        });
+
+        it('when get empty array should remove saved sessions', () => {
+            expect(Object.keys(getSessionEntities(state)).length).toEqual(2);
+            state = stateWith(reducer(state.sessions.sessions, new SearchComplete([])));
+            expect(Object.keys(getSessionEntities(state)).length).toEqual(0);
+        });
+    });
+});
+
+function stateWith(sessionReducer): State {
+    return { sessions: { sessions: sessionReducer, rooms: null, sessionTransaction: null }}
+};
+
+function generateSession(id: string): Session {
+    return {
+        id: id,
+        start: null,
+        duration: null,
+        room: null,
+        person: null,
+        caseType: null,
+        hearingTypes: [],
+        jurisdiction: 'some jurisdiction',
+        version: 0
+    }
+};


### PR DESCRIPTION
There was a problem on frontend when data in DB has been dropped and API returns an empty array, frontend was still keeping and displaying these obsolete data. 
I've fixed it + covered it with unit tests