### PR TITLE
[PREVIEW] SL- 1516 Add additional detail to display on problems page

### DIFF
--- a/e2e/components/table.ts
+++ b/e2e/components/table.ts
@@ -16,7 +16,7 @@ export class Table {
     return row;
   }
 
-  private async rowThatContains(...values: string[]): Promise<ElementFinder> {
+  async rowThatContains(...values: string[]): Promise<ElementFinder> {
     const rows = await this.parentElement.all(by.css('mat-row')).asElementFinders_()
     const selectedRow = await filterSeries(rows, async (row: ElementFinder): Promise<boolean> => {
       const rowText = await row.getText()

--- a/e2e/e2e-url.js
+++ b/e2e/e2e-url.js
@@ -15,6 +15,6 @@ var localEnv = {
     apiURL: "http://localhost:8090"
 };
 
-module.exports = attEnv;
-// module.exports = prEnv;
-//module.exports = localEnv;
+//module.exports = attEnv;
+//module.exports = prEnv;
+module.exports = localEnv;

--- a/e2e/flows/navigation.flow.ts
+++ b/e2e/flows/navigation.flow.ts
@@ -1,5 +1,6 @@
 import { TopMenu } from '../pages/top-menu.po';
 import { CalendarPage } from '../pages/calendar.po';
+import { Logger } from '../utils/logger';
 
 export class NavigationFlow {
   topMenu = new TopMenu();
@@ -22,6 +23,11 @@ export class NavigationFlow {
   }
 
   async goToAmendSessionsListPage() {
-      await this.topMenu.openSessionsAmendListPage();
+    await this.topMenu.openSessionsAmendListPage();
+  }
+
+  async goToProblemsPage() {
+    Logger.log(`Opening problems page`);
+    await this.topMenu.openProblemsPage();
   }
 }

--- a/e2e/pages/problems.po.ts
+++ b/e2e/pages/problems.po.ts
@@ -1,0 +1,31 @@
+import { browser, by, element, ExpectedConditions } from 'protractor';
+import { Wait } from '../enums/wait';
+import { Table } from '../components/table';
+import { Logger } from '../utils/logger';
+
+export class ProblemsPage {
+    private containerElement = element(by.css('app-problems-page'))
+    public problemsTable = new Table(element(by.css('app-problems-table')));
+
+    async waitUntilVisible() {
+        Logger.log(`Waiting for Problems page to be visible`);
+        await browser.wait(ExpectedConditions.visibilityOf(this.containerElement), Wait.normal, 'Problems page is not visible');
+    }
+
+    async isProblemDisplayed(values: string[]): Promise<boolean> {
+        Logger.log(`Checking if problem with values: '${values}' is displayed`);
+        const row = await this.problemsTable.rowThatContains(...values);
+        await browser.wait(ExpectedConditions.presenceOf(row), Wait.normal, `Problem row with values: '${values}' is not present`);
+        return await row.isPresent();
+    }
+
+    async getNumberOfProblems() {
+        Logger.log(`Getting number of problem from paginator element`);
+        const paginatorRangeElement = element(by.className('mat-paginator-range-label'))
+        await browser.wait(ExpectedConditions.visibilityOf(paginatorRangeElement), Wait.normal)
+        const paginationRangeText = await paginatorRangeElement.getText()
+        const totalNumberOfProblems = paginationRangeText.split('of').pop().trim()
+        Logger.log(`Number of problems in paginator: ${totalNumberOfProblems}`);
+        return +totalNumberOfProblems
+    }
+}

--- a/e2e/pages/top-menu.po.ts
+++ b/e2e/pages/top-menu.po.ts
@@ -4,16 +4,19 @@ import { element, by, browser, ExpectedConditions } from 'protractor';
 import { Wait } from '../enums/wait';
 import { SessionSearchPage } from './session-search.po';
 import { SessionAmendListPage } from './session-amend-list.po';
+import { ProblemsPage } from './problems.po';
 
 export class TopMenu {
   private parentElement = element(by.css('mat-toolbar-row'));
   private listingsButtonSelector = by.cssContainingText('.mat-button-wrapper', 'Listings');
   private calendarButtonSelector = by.cssContainingText('.mat-button-wrapper', 'Calendar');
+  private problemsButtonSelector = by.cssContainingText('.mat-button-wrapper', 'Problems');
   private logoutButtonElement = element(by.cssContainingText('.mat-button-wrapper', 'Logout'))
   private sessionCreatePage = new SessionCreationPage()
   private sessionSearchPage = new SessionSearchPage()
   private listingCreatePage = new ListingCreationPage()
   private sessionAmendListPage = new SessionAmendListPage();
+  private problemsPage = new ProblemsPage();
 
   async openNewSessionPage() {
     await this.openListingSubMenu('New Session');
@@ -46,6 +49,11 @@ export class TopMenu {
 
   async clickOnLogoutButton() {
     await this.logoutButtonElement.click()
+  }
+
+  async openProblemsPage() {
+    await element(this.problemsButtonSelector).click()
+    await this.problemsPage.waitUntilVisible()
   }
 
   private async openListingSubMenu(optionName: string): Promise<void> {

--- a/e2e/pages/top-menu.po.ts
+++ b/e2e/pages/top-menu.po.ts
@@ -10,7 +10,7 @@ export class TopMenu {
   private parentElement = element(by.css('mat-toolbar-row'));
   private listingsButtonSelector = by.cssContainingText('.mat-button-wrapper', 'Listings');
   private calendarButtonSelector = by.cssContainingText('.mat-button-wrapper', 'Calendar');
-  private problemsButtonSelector = by.cssContainingText('.mat-button-wrapper', 'Problems');
+  private problemsButtonElement = element(by.cssContainingText('.mat-button-wrapper', 'Problems'));
   private logoutButtonElement = element(by.cssContainingText('.mat-button-wrapper', 'Logout'))
   private sessionCreatePage = new SessionCreationPage()
   private sessionSearchPage = new SessionSearchPage()
@@ -52,7 +52,8 @@ export class TopMenu {
   }
 
   async openProblemsPage() {
-    await element(this.problemsButtonSelector).click()
+    await browser.wait(ExpectedConditions.elementToBeClickable(this.problemsButtonElement), Wait.normal)
+    await this.problemsButtonElement.click()
     await this.problemsPage.waitUntilVisible()
   }
 

--- a/e2e/pages/transaction-dialog.po.ts
+++ b/e2e/pages/transaction-dialog.po.ts
@@ -19,6 +19,7 @@ export class TransactionDialogPage {
     await browser.wait(ExpectedConditions.visibilityOf(acceptButton), Wait.long, 'Accept button is not visible');
     await acceptButton.click();
     await browser.wait(ExpectedConditions.invisibilityOf(acceptButton), Wait.long, 'Accept button wont disappear');
+    await browser.wait(ExpectedConditions.invisibilityOf(element(by.className('cdk-overlay-pane'))), Wait.long)
     return await browser.waitForAngular()
   }
 

--- a/e2e/specs/problem-list.e2e-spec.ts
+++ b/e2e/specs/problem-list.e2e-spec.ts
@@ -8,6 +8,7 @@ import { ProblemsPage } from '../pages/problems.po';
 import { protractor } from 'protractor/built/ptor';
 import { waitFor } from '../utils/wait-for';
 import { forEachSeries } from 'p-iteration';
+import { browser } from 'protractor';
 
 const navigationFlow = new NavigationFlow();
 const loginFlow = new LoginFlow();
@@ -69,6 +70,7 @@ describe('Problem list tests', () => {
 
         it('Refresh page, new problems should be visible in table', async () => {
             await protractor.browser.refresh();
+            await browser.waitForAngular()
             await navigationFlow.goToProblemsPage();
             const numberOfProblemsAfterSessionCreation = await problemsPage.getNumberOfProblems()
 

--- a/e2e/specs/problem-list.e2e-spec.ts
+++ b/e2e/specs/problem-list.e2e-spec.ts
@@ -1,0 +1,83 @@
+import { NavigationFlow } from '../flows/navigation.flow';
+import * as moment from 'moment';
+import { LoginFlow } from '../flows/login.flow';
+import { SessionCreate } from '../../src/app/sessions/models/session-create.model';
+import { API } from '../utils/api';
+import { v4 as uuid } from 'uuid';
+import { ProblemsPage } from '../pages/problems.po';
+import { protractor } from 'protractor/built/ptor';
+import { waitFor } from '../utils/wait-for';
+import { forEachSeries } from 'p-iteration';
+
+const navigationFlow = new NavigationFlow();
+const loginFlow = new LoginFlow();
+const problemsPage = new ProblemsPage()
+
+const in5Minutes = moment().add(5, 'minute');
+
+const sessionCreate: SessionCreate = {
+    id: uuid(),
+    userTransactionId: uuid(),
+    personId: null,
+    roomId: null,
+    duration: 1800,
+    start: in5Minutes,
+    sessionTypeCode: 'fast-track---trial-only',
+    caseType: undefined
+};
+
+let numberOfProblems: number;
+let problemsBeforeAction;
+let newProblems;
+const numberOfExpectedProblems = 3 // because, Room & judge not set + is listed less than 50%
+
+const displayValuesFromProblems = (problems: any[]): string[][] => {
+    return problems.map((problem) => {
+        const createdAt = moment(problem.createdAt).format('YYYY-MM-DD HH:mm')
+        return [problem.severity, createdAt, problem.message]
+    })
+}
+
+describe('Problem list tests', () => {
+    describe('Go to Problems page', () => {
+        beforeAll(async () => {
+            await loginFlow.loginIfNeeded();
+            await navigationFlow.goToProblemsPage();
+        });
+
+        it('Remember number of problems', async () => {
+            problemsBeforeAction = (await API.getProblems()) as any[]
+            numberOfProblems = await problemsPage.getNumberOfProblems()
+            expect(numberOfProblems).toEqual(problemsBeforeAction.length)
+        });
+
+        it('create session via API for now, it should return 200 and create problems', async () => {
+            const statusCode = await API.createSession(sessionCreate)
+            expect(statusCode).toEqual(200)
+        });
+
+        it('wait until new problems will be generated', async () => {
+            const result = await waitFor(5, async () => {
+                const alreadyKnownIds = problemsBeforeAction.map(problem => problem.id)
+                const problems = (await API.getProblems()) as any[]
+                newProblems = problems.filter(x => !alreadyKnownIds.includes(x.id));
+                return newProblems.length === numberOfExpectedProblems
+            })
+
+            expect(result).toBeTruthy('New problems has not been returned from API yet')
+        });
+
+        it('Refresh page, new problems should be visible in table', async () => {
+            await protractor.browser.refresh();
+            await navigationFlow.goToProblemsPage();
+            const numberOfProblemsAfterSessionCreation = await problemsPage.getNumberOfProblems()
+
+            await forEachSeries(displayValuesFromProblems(newProblems), async (problemValues) => {
+                const areProblemsDisplayed = await problemsPage.isProblemDisplayed(problemValues)
+                expect(areProblemsDisplayed).toBeTruthy()
+            })
+
+            expect(numberOfProblems + numberOfExpectedProblems).toEqual(numberOfProblemsAfterSessionCreation)
+        });
+    });
+});

--- a/e2e/specs/problem-list.e2e-spec.ts
+++ b/e2e/specs/problem-list.e2e-spec.ts
@@ -34,7 +34,7 @@ const numberOfExpectedProblems = 3 // because, Room & judge not set + is listed 
 
 const displayValuesFromProblems = (problems: any[]): string[][] => {
     return problems.map((problem) => {
-        const createdAt = moment(problem.createdAt).format('YYYY-MM-DD HH:mm')
+        const createdAt = moment(problem.createdAt).format('DD/MM/YYYY HH:mm')
         return [problem.severity, createdAt, problem.message]
     })
 }

--- a/e2e/utils/api.ts
+++ b/e2e/utils/api.ts
@@ -58,6 +58,8 @@ export class API {
     }
 
     private static async login() {
+        if (API.headers.Authorization.length > 0) { return }
+
         const options = {
             method: 'POST',
             uri: `${API.baseUrl}/security/signin`,

--- a/e2e/utils/api.ts
+++ b/e2e/utils/api.ts
@@ -7,6 +7,8 @@ import * as URL from '../e2e-url.js'
 const rp = (URL.proxy) ? requestPromise.defaults({ proxy: URL.proxy, strictSSL: false}) : requestPromise;
 const apiURL = process.env.SNL_API_URL || URL.apiURL;
 
+console.log('ENV Vars: ' + process.env)
+
 console.log('API URL: ' + apiURL)
 
 export class API {
@@ -42,6 +44,19 @@ export class API {
         await API.commitUserTransaction(body)
 
         return response.statusCode;
+    }
+
+    static async getProblems() {
+        await API.login();
+        const options = {
+            method: 'GET',
+            uri: `${API.baseUrl}/problems`,
+            headers: API.headers,
+            resolveWithFullResponse: true
+        }
+        const response = await rp(options)
+        const responseBody = JSON.parse(response.body)
+        return responseBody;
     }
 
     private static async login() {

--- a/e2e/utils/api.ts
+++ b/e2e/utils/api.ts
@@ -5,9 +5,7 @@ import * as requestPromise from 'request-promise'
 import * as URL from '../e2e-url.js'
 
 const rp = (URL.proxy) ? requestPromise.defaults({ proxy: URL.proxy, strictSSL: false}) : requestPromise;
-const apiURL = process.env.SNL_API_URL || URL.apiURL;
-
-console.log('ENV Vars: ' + process.env)
+const apiURL = (process.env.TEST_URL) ? 'http://snl-api-aat.service.core-compute-aat.internal' : URL.apiURL;
 
 console.log('API URL: ' + apiURL)
 

--- a/e2e/utils/wait-for.ts
+++ b/e2e/utils/wait-for.ts
@@ -1,0 +1,15 @@
+export const waitFor = (numOfSeconds, until: (() => Promise<boolean>), msIntervals = 500): Promise<boolean> => {
+    return new Promise((resolve, reject) => {
+        let timeOut = numOfSeconds * 1000
+        const interval = setInterval(async () => {
+            if (await until()) {
+                clearInterval(interval)
+                return resolve(true)
+            }
+            timeOut -= msIntervals;
+            if (timeOut <= 0) {
+                return resolve(false)
+            }
+        }, msIntervals);
+    })
+}

--- a/src/app/admin/components/poc/poc.component.ts
+++ b/src/app/admin/components/poc/poc.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { PocService } from '../../services/poc-service';
+import * as moment from 'moment'
 
 @Component({
   selector: 'app-poc',
@@ -10,9 +11,9 @@ export class PocComponent implements OnInit {
 
   loadRulesFromDbResult: string;
   timeSet: string;
-  yearRequestBody = {timeType: 'year', value: 0} as TimeRequestBody;
-  monthRequestBody = {timeType: 'month', value: 0} as TimeRequestBody;
-  dayRequestBody = {timeType: 'day', value: 0} as TimeRequestBody;
+  yearRequestBody = {timeType: 'year', value: +moment().format('YYYY')} as TimeRequestBody;
+  monthRequestBody = {timeType: 'month', value: +moment().format('M')} as TimeRequestBody;
+  dayRequestBody = {timeType: 'day', value: +moment().format('D')} as TimeRequestBody;
   hourRequestBody = {timeType: 'hour', value: 0} as TimeRequestBody;
   minuteRequestBody = {timeType: 'minute', value: 0} as TimeRequestBody;
 

--- a/src/app/features/transactions/components/transaction-dialog/transaction-dialog.component.spec.ts
+++ b/src/app/features/transactions/components/transaction-dialog/transaction-dialog.component.spec.ts
@@ -26,7 +26,8 @@ const mockedProblems: Problem[] = [
     message: 'some-msg',
     severity: 'some-severity',
     type: 'some-type',
-    references: undefined
+    references: undefined,
+    createdAt: undefined
   }
 ];
 const mockEntityTransaction: EntityTransaction = {

--- a/src/app/problems/components/problems-table/problems-table.component.html
+++ b/src/app/problems/components/problems-table/problems-table.component.html
@@ -4,7 +4,7 @@
     <mat-header-cell *matHeaderCellDef> Severity </mat-header-cell>
     <mat-cell *matCellDef="let element"> 
       <mat-chip-list>
-        <mat-chip>{{element.severity}}</mat-chip>
+        <mat-chip [ngClass]="{'critical': element.severity === 'Critical', 'urgent': element.severity === 'Urgent'}">{{element.severity}}</mat-chip>
       </mat-chip-list>
     </mat-cell>
   </ng-container>

--- a/src/app/problems/components/problems-table/problems-table.component.html
+++ b/src/app/problems/components/problems-table/problems-table.component.html
@@ -1,18 +1,24 @@
 <mat-table #table [dataSource]="dataSource">
 
-  <!-- Position Column -->
-  <ng-container matColumnDef="id">
-    <mat-header-cell *matHeaderCellDef> Id </mat-header-cell>
-    <mat-cell *matCellDef="let element"> {{element.id}}</mat-cell>
+  <ng-container matColumnDef="severity">
+    <mat-header-cell *matHeaderCellDef> Severity </mat-header-cell>
+    <mat-cell *matCellDef="let element"> 
+      <mat-chip-list>
+        <mat-chip>{{element.severity}}</mat-chip>
+      </mat-chip-list>
+    </mat-cell>
   </ng-container>
 
-  <!-- Name Column -->
+  <ng-container matColumnDef="createdAt">
+      <mat-header-cell *matHeaderCellDef> Created At </mat-header-cell>
+      <mat-cell *matCellDef="let element"> {{ formatDate(element.createdAt) }}</mat-cell>
+    </ng-container>
+
   <ng-container matColumnDef="message">
     <mat-header-cell *matHeaderCellDef> Message </mat-header-cell>
     <mat-cell *matCellDef="let element"> {{element.message}} </mat-cell>
   </ng-container>
 
-  <!-- Ref description Column -->
   <ng-container matColumnDef="references description">
     <mat-header-cell *matHeaderCellDef> References description </mat-header-cell>
     <mat-cell *matCellDef="let element">

--- a/src/app/problems/components/problems-table/problems-table.component.scss
+++ b/src/app/problems/components/problems-table/problems-table.component.scss
@@ -1,10 +1,10 @@
-.mat-column-id {
-  flex: 0 0 300px;
-  margin-right: 20px;
+.mat-column-severity {
+  max-width: 90px;
+}
+.mat-column-createdAt {
+  max-width: 130px;
 }
 .mat-column-message {
-  flex: 1;
-  max-width: 400px;
   margin-right: 20px;
 }
 /deep/.mat-column-references-description ul {
@@ -12,4 +12,10 @@
   li:first-letter {
     text-transform:capitalize;
   }
+}
+.critical {
+  background-color: #E91E63;
+}
+.urgent {
+  background-color: #283593;
 }

--- a/src/app/problems/components/problems-table/problems-table.component.scss
+++ b/src/app/problems/components/problems-table/problems-table.component.scss
@@ -17,5 +17,5 @@
   background-color: #E91E63;
 }
 .urgent {
-  background-color: #283593;
+  background-color: #B3E5FC;
 }

--- a/src/app/problems/components/problems-table/problems-table.component.ts
+++ b/src/app/problems/components/problems-table/problems-table.component.ts
@@ -32,6 +32,6 @@ export class ProblemsTableComponent implements OnInit, OnChanges {
   }
 
   formatDate(date: Moment): string {
-    return date.format('YYYY-MM-DD HH:mm')
+    return date.format('DD/MM/YYYY HH:mm')
   }
 }

--- a/src/app/problems/components/problems-table/problems-table.component.ts
+++ b/src/app/problems/components/problems-table/problems-table.component.ts
@@ -2,6 +2,7 @@ import { ProblemReference } from '../../models/problem-reference.model';
 import { Component, Input, OnChanges, OnInit, ViewChild } from '@angular/core';
 import { Problem } from '../../models/problem.model';
 import { MatPaginator, MatTableDataSource } from '@angular/material';
+import { Moment } from 'moment';
 
 @Component({
   selector: 'app-problems-table',
@@ -9,7 +10,7 @@ import { MatPaginator, MatTableDataSource } from '@angular/material';
   styleUrls: ['./problems-table.component.scss']
 })
 export class ProblemsTableComponent implements OnInit, OnChanges {
-  displayedColumns = ['id', 'message', 'references description'];
+  displayedColumns = ['severity', 'createdAt', 'message', 'references description'];
   dataSource;
 
   @Input() problems: Problem[];
@@ -28,5 +29,9 @@ export class ProblemsTableComponent implements OnInit, OnChanges {
   extractRefDescriptions(element: Problem): string[] {
     return element.references
       .map((reference: ProblemReference) => `${reference.entity}: ${reference.description}`);
+  }
+
+  formatDate(date: Moment): string {
+    return date.format('YYYY-MM-DD HH:mm')
   }
 }

--- a/src/app/problems/containers/problems/problems-page.component.spec.ts
+++ b/src/app/problems/containers/problems/problems-page.component.spec.ts
@@ -5,27 +5,54 @@ import { Problem } from '../../models/problem.model';
 import { reducers } from '../../reducers';
 import * as problemsActions from '../../actions/problem.action';
 import * as fromProblems from '../../reducers';
+import * as moment from 'moment';
 
 let problemsPageComponent: ProblemsPageComponent;
 let storeSpy: jasmine.Spy;
 let store: Store<fromProblems.State>;
 
-const problems = [
-    {
-        id: '1',
-        message: undefined,
-        severity: undefined,
-        type: undefined,
-        references: undefined
-    },
-    {
-        id: '2',
-        message: undefined,
-        severity: undefined,
-        type: undefined,
-        references: undefined
-    }
-] as Problem[];
+const theNewestProblem: Problem = {
+    id: '1',
+    message: undefined,
+    severity: undefined,
+    type: undefined,
+    references: undefined,
+    createdAt: moment()
+}
+
+const theOldestProblem: Problem = {
+    id: '3',
+    message: undefined,
+    severity: undefined,
+    type: undefined,
+    references: undefined,
+    createdAt: moment().subtract(2, 'hours')
+}
+
+const middleProblem: Problem = {
+    id: '2',
+    message: undefined,
+    severity: undefined,
+    type: undefined,
+    references: undefined,
+    createdAt: moment().subtract(1, 'hours')
+}
+
+const problemWithUndefinedCreatedAt: Problem = {
+    id: '4',
+    message: undefined,
+    severity: undefined,
+    type: undefined,
+    references: undefined,
+    createdAt: moment(null)
+}
+
+const problems: Problem[] = [
+    problemWithUndefinedCreatedAt,
+    theNewestProblem,
+    theOldestProblem,
+    middleProblem
+];
 
 describe('ProblemsPageComponent', () => {
     beforeEach(() => {
@@ -57,7 +84,20 @@ describe('ProblemsPageComponent', () => {
         store.dispatch(new problemsActions.GetComplete(problems));
 
         problemsPageComponent.problems$.subscribe(data => {
-            expect(data).toEqual(problems);
+            expect(data.length).toEqual(problems.length);
+            problems.forEach(problem => expect(data).toContain(problem))
         })
+    });
+
+    describe('sortByCreatedAtDescending', () => {
+        it('should sort by created at property - the newest problems should be first', () => {
+            const sortedProblems = problemsPageComponent.sortByCreatedAtDescending(problems)
+            expect(sortedProblems).toEqual([
+                theNewestProblem,
+                middleProblem,
+                theOldestProblem,
+                problemWithUndefinedCreatedAt
+            ])
+        });
     });
 });

--- a/src/app/problems/containers/problems/problems-page.component.ts
+++ b/src/app/problems/containers/problems/problems-page.component.ts
@@ -16,11 +16,26 @@ export class ProblemsPageComponent implements OnInit {
     problems$: Observable<Problem[]>;
 
     constructor(private readonly store: Store<fromProblems.State>) {
-        this.problems$ = this.store.pipe(select(fromProblems.getProblemsEntities), map(data => data ? Object.values(data) : []));
+        this.problems$ = this.store.pipe(
+            select(fromProblems.getProblems),
+            map(data => data ? Object.values(data) : []),
+            map(this.sortByCreatedAtDescending));
     }
 
     ngOnInit() {
         this.store.dispatch(new fromProblemsPartsActions.Get())
+    }
+
+    sortByCreatedAtDescending(problems: Problem[]): Problem[] {
+        return problems.sort((a, b) => {
+            if (!a.createdAt.isValid()) {
+                return 1;
+            } else if (!b.createdAt.isValid()) {
+                return -1;
+            } else {
+                return b.createdAt.diff(a.createdAt)
+            }
+        });
     }
 
 }

--- a/src/app/problems/models/problem.model.ts
+++ b/src/app/problems/models/problem.model.ts
@@ -1,4 +1,5 @@
 import { ProblemReference } from './problem-reference.model';
+import * as moment from 'moment';
 
 export interface Problem {
     id: string;
@@ -6,4 +7,5 @@ export interface Problem {
     severity: string;
     type: string;
     references: ProblemReference[];
+    createdAt: moment.Moment
 }

--- a/src/app/problems/problems.module.ts
+++ b/src/app/problems/problems.module.ts
@@ -8,11 +8,13 @@ import { reducers } from './reducers';
 import { ProblemsService } from './services/problems.service';
 import { ProblemsPageComponent } from './containers/problems/problems-page.component';
 import { AngularMaterialModule } from '../../angular-material/angular-material.module';
+import { MatChipsModule } from '@angular/material/chips';
 
 @NgModule({
   imports: [
     CommonModule,
     AngularMaterialModule,
+    MatChipsModule,
     StoreModule.forFeature('problems', reducers),
     EffectsModule.forFeature([ProblemEffects])
   ],

--- a/src/app/problems/reducers/index.spec.ts
+++ b/src/app/problems/reducers/index.spec.ts
@@ -1,0 +1,24 @@
+import { getProblems } from './index';
+import { Dictionary } from '@ngrx/entity/src/models';
+import { Problem } from '../models/problem.model';
+
+const problemDict = {
+    '1': {
+        id: '1',
+        message: undefined,
+        severity: undefined,
+        type: undefined,
+        references: undefined,
+        createdAt: '2008-09-15T15:53:00+05:00'
+    }
+}
+
+describe('Problem selectors', () => {
+    describe('getProblems', () => {
+        it('should return problems with createdAt property as moment', () => {
+            const problemsDict: Dictionary<Problem> = getProblems.projector(problemDict)
+            const problem: Problem = Object.values(problemsDict)[0]
+            expect(problem.createdAt.isValid()).toBeTruthy()
+        })
+    });
+})

--- a/src/app/problems/reducers/index.ts
+++ b/src/app/problems/reducers/index.ts
@@ -32,12 +32,13 @@ export const getProblems = createSelector<any, Dictionary<Problem>, Dictionary<P
     getProblemsEntitiesArray,
     (problemEntities) => {
         if (!problemEntities) { return {} }
+        const transformedProblemEntities = Object.assign({}, problemEntities); ;
 
-        Object.keys(problemEntities).map((key) => {
-            problemEntities[key].createdAt = moment(problemEntities[key].createdAt);
+        Object.keys(transformedProblemEntities).map((key) => {
+            transformedProblemEntities[key].createdAt = moment(transformedProblemEntities[key].createdAt);
          });
 
-        return problemEntities;
+        return transformedProblemEntities;
     }
 );
 

--- a/src/app/problems/reducers/index.ts
+++ b/src/app/problems/reducers/index.ts
@@ -34,9 +34,9 @@ export const getProblems = createSelector<any, Dictionary<Problem>, Dictionary<P
         if (!problemEntities) { return {} }
         const transformedProblemEntities = Object.assign({}, problemEntities); ;
 
-        Object.keys(transformedProblemEntities).map((key) => {
+        Object.keys(transformedProblemEntities).forEach((key) => {
             transformedProblemEntities[key].createdAt = moment(transformedProblemEntities[key].createdAt);
-         });
+        });
 
         return transformedProblemEntities;
     }

--- a/src/app/problems/reducers/index.ts
+++ b/src/app/problems/reducers/index.ts
@@ -1,6 +1,9 @@
 import * as fromRoot from '../../app.state';
 import * as fromProblems from './problem.reducer';
 import { ActionReducerMap, createFeatureSelector, createSelector } from '@ngrx/store';
+import { Dictionary } from '@ngrx/entity/src/models';
+import { Problem } from '../models/problem.model';
+import * as moment from 'moment';
 
 export interface ProblemsState {
     readonly problems: fromProblems.State;
@@ -20,9 +23,22 @@ export const getProblemsEntitiesState = createSelector(
     state => state.problems
 );
 
-export const getProblems = createSelector(
+export const getProblemsEntitiesArray = createSelector(
     getProblemsEntitiesState,
     state => state.entities
+);
+
+export const getProblems = createSelector<any, Dictionary<Problem>, Dictionary<Problem>>(
+    getProblemsEntitiesArray,
+    (problemEntities) => {
+        if (!problemEntities) { return {} }
+
+        Object.keys(problemEntities).map((key) => {
+            problemEntities[key].createdAt = moment(problemEntities[key].createdAt);
+         });
+
+        return problemEntities;
+    }
 );
 
 export const getProblemsLoading = createSelector(

--- a/src/app/problems/reducers/problem.reducer.spec.ts
+++ b/src/app/problems/reducers/problem.reducer.spec.ts
@@ -2,42 +2,46 @@ import { reducer } from './problem.reducer';
 import { Get, GetComplete, GetFailed, RemoveAll, UpsertMany } from '../actions/problem.action';
 import { Problem } from '../models/problem.model';
 
-const problems = [
+const problems: Problem[] = [
     {
         id: '1',
         message: undefined,
         severity: undefined,
         type: undefined,
-        references: undefined
+        references: undefined,
+        createdAt: undefined
     },
     {
         id: '2',
         message: undefined,
         severity: undefined,
         type: undefined,
-        references: undefined
+        references: undefined,
+        createdAt: undefined
     }
-] as Problem[];
+]
 
 const problemsEntities = {
     '1': problems[0],
     '2': problems[1]
 };
 
-const problemsUpsert = [
+const problemsUpsert: Problem[] = [
     {
         id: '1',
         message: 'some msg',
         severity: undefined,
         type: undefined,
-        references: undefined
+        references: undefined,
+        createdAt: undefined
     },
     {
         id: '2',
         message: undefined,
         severity: undefined,
         type: 'abcde',
-        references: undefined
+        references: undefined,
+        createdAt: undefined
     }
 ];
 
@@ -59,7 +63,6 @@ describe('ProblemReducer', () => {
 
         expect(state.loading).toEqual(false)
         expect(state.entities).toEqual(problemsEntities)
-
     });
 
     it('should set loading to false and give error', () => {


### PR DESCRIPTION
Extended Problems model about createdAt property + added mapper to moment while selecting from the store.
Added sorting problems by date (the newest at the top)
This PR  depends on https://github.com/hmcts/snl-rules/pull/63 and https://github.com/hmcts/snl-events/pull/126