### PR TITLE
[PREVIEW] SL-1535 Tidy up creation of listing request

### DIFF
--- a/e2e/models/create-listing-request-body.ts
+++ b/e2e/models/create-listing-request-body.ts
@@ -2,9 +2,9 @@ export interface CreateListingRequestBody {
     id: string;
     caseNumber: string;
     caseTitle: string;
-    caseType: string;
+    caseTypeCode: string;
+    hearingTypeCode: string;
     duration: string;
     priority: string;
     userTransactionId: string;
-    hearingType: string;
 }

--- a/e2e/pages/transaction-dialog.po.ts
+++ b/e2e/pages/transaction-dialog.po.ts
@@ -1,9 +1,9 @@
-import { element, by, ExpectedConditions, browser } from 'protractor';
+import { element, by, ExpectedConditions, browser, ElementFinder } from 'protractor';
 import { Wait } from '../enums/wait';
 
 export class TransactionDialogPage {
   private parentElement = element(by.className('mat-dialog-container'));
-  private summaryCreationElement = this.parentElement.element(by.id('sessionCreationSummary'));
+  private actionCreationElement = this.parentElement.element(by.id('actionSummary'));
   private sessionButtonSelector = this.parentElement.element(by.cssContainingText('.mat-button-wrapper', 'Sessions'));
   private problemsDiv = element(by.id('problems'));
 
@@ -14,22 +14,21 @@ export class TransactionDialogPage {
 
   async clickAcceptButton(): Promise<any> {
     const acceptButton = element(by.id('okButton'));
-    await browser.wait(ExpectedConditions.presenceOf(acceptButton), Wait.normal);
-    await browser.executeScript('arguments[0].scrollIntoView();', acceptButton.getWebElement());
-    await browser.wait(ExpectedConditions.visibilityOf(acceptButton), Wait.long, 'Accept button is not visible');
-    await acceptButton.click();
-    await browser.wait(ExpectedConditions.invisibilityOf(acceptButton), Wait.long, 'Accept button wont disappear');
-    await browser.wait(ExpectedConditions.invisibilityOf(element(by.className('cdk-overlay-pane'))), Wait.long)
-    return await browser.waitForAngular()
+    return await this.clickDialogButton(acceptButton, 'Accept')
   }
 
-  async isSessionCreationSummaryDisplayed(): Promise<boolean> {
+  async clickRollbackButton(): Promise<any> {
+    const rollbackButton = element(by.id('rollbackButton'));
+    return await this.clickDialogButton(rollbackButton, 'Rollback')
+  }
+
+  async isActionCreationSummaryDisplayed(): Promise<boolean> {
     await browser.wait(
-      ExpectedConditions.visibilityOf(this.summaryCreationElement),
+      ExpectedConditions.visibilityOf(this.actionCreationElement),
       Wait.normal,
-      'Session Creation Summary is not visible'
+      'Action Creation Summary is not visible'
     );
-    return await this.summaryCreationElement.isDisplayed();
+    return await this.actionCreationElement.isDisplayed();
   }
 
   async isProblemWithTextDisplayed(problemText: string): Promise<boolean> {
@@ -40,5 +39,15 @@ export class TransactionDialogPage {
     );
     const problemsDivText = await this.problemsDiv.getText();
     return await Promise.resolve(problemsDivText.indexOf(problemText) !== -1);
+  }
+
+  private async clickDialogButton(buttonElement: ElementFinder, buttonName: string) {
+    await browser.wait(ExpectedConditions.presenceOf(buttonElement), Wait.normal);
+    await browser.executeScript('arguments[0].scrollIntoView();', buttonElement.getWebElement());
+    await browser.wait(ExpectedConditions.visibilityOf(buttonElement), Wait.long, `${buttonName} button is not visible`);
+    await buttonElement.click();
+    await browser.wait(ExpectedConditions.invisibilityOf(buttonElement), Wait.long, `${buttonElement} button wont disappear`);
+    await browser.wait(ExpectedConditions.invisibilityOf(element(by.className('cdk-overlay-pane'))), Wait.long)
+    return await browser.waitForAngular()
   }
 }

--- a/e2e/specs/amend-listing-request.e2e-spec.ts
+++ b/e2e/specs/amend-listing-request.e2e-spec.ts
@@ -9,6 +9,7 @@ import * as moment from 'moment';
 import { ListingCreationForm } from '../models/listing-creation-form';
 import { TransactionDialogPage } from '../pages/transaction-dialog.po';
 import { API }from '../utils/api';
+import { CreateListingRequestBody } from '../models/create-listing-request-body';
 
 const now = moment()
 const todayDate = now.format('DD/MM/YYYY')
@@ -40,15 +41,8 @@ const displayedListingRequestData = {
   priority
 };
 
-const listingRequest = {
-  id,
-  duration,
-  userTransactionId,
-  ...displayedListingRequestData
-};
-
-const listingRequestCreate = {
-    ...listingRequest, caseType: 'small-claims',  hearingType: 'trial'
+const listingRequestCreate: CreateListingRequestBody = {
+    id, caseNumber, caseTitle, priority, duration, userTransactionId, caseTypeCode: 'small-claims',  hearingTypeCode: 'trial'
 }
 
 describe('Amend Listing Request', () => {

--- a/e2e/specs/create-listing-request.e2e-spec.ts
+++ b/e2e/specs/create-listing-request.e2e-spec.ts
@@ -1,0 +1,75 @@
+import { LoginFlow } from '../flows/login.flow';
+import { NavigationFlow } from '../flows/navigation.flow';
+import { CaseTypes } from '../enums/case-types';
+import { HearingTypes } from '../enums/hearing-types';
+import { ListingCreationPage } from '../pages/listing-creation.po';
+import * as moment from 'moment';
+import { ListingCreationForm } from '../models/listing-creation-form';
+import { TransactionDialogPage } from '../pages/transaction-dialog.po';
+import { API }from '../utils/api';
+import { waitFor } from '../utils/wait-for';
+import { Wait } from '../enums/wait';
+
+const loginFlow: LoginFlow = new LoginFlow();
+const navigationFlow: NavigationFlow = new NavigationFlow();
+const listingCreationPage = new ListingCreationPage();
+const transactionDialogPage = new TransactionDialogPage()
+let numberOfHearingParts: number;
+
+const todayDate = moment().format('DD/MM/YYYY')
+const tomorrowString = moment().add(1, 'day').format('DD/MM/YYYY')
+const formValues: ListingCreationForm = {
+  caseNumber: 'e2e case number' + moment().toISOString(),
+  caseTitle: 'e2e case title' + moment().toISOString(),
+  caseType: CaseTypes.FTRACK,
+  hearingType: HearingTypes.TRIAL,
+  duration: 60,
+  fromDate: tomorrowString,
+  endDate: tomorrowString
+}
+
+describe('Create Listing Request', () => {
+  beforeAll(async () => {
+    await loginFlow.loginIfNeeded()
+  });
+  describe('Get number of hearing parts', () => {
+    it('should save count of listing request', async () => {
+      numberOfHearingParts = (await API.getHearingParts() as any[]).length
+    });
+  });
+  describe('Go to create hearing page', () => {
+    it('created hearing page should be visible', async () => {
+      await navigationFlow.goToNewListingRequestPage()
+    });
+  });
+  describe('Fill in a form, set start & end dates for tomorrow', () => {
+    it('popup with problems should appear', async () => {
+      await listingCreationPage.createListingRequest(formValues)
+      const problemText = 'Listing request target schedule to date is 4 weeks or nearer from today and it has not been listed yet - Warning'
+      const isProblemDisplayed = await transactionDialogPage.isProblemWithTextDisplayed(problemText)
+      expect(isProblemDisplayed).toBeTruthy()
+    });
+    it('click rollback, new hearing part should not be created', async () => {
+      transactionDialogPage.clickRollbackButton()
+      const isHearingPartCreatedWhenRollback = await waitFor(Wait.normal, async () => {
+        const numberOfHearingPartsAfterRollback = (await API.getHearingParts() as any[]).length
+        return numberOfHearingParts === numberOfHearingPartsAfterRollback
+    })
+
+      expect(isHearingPartCreatedWhenRollback).toBeTruthy()
+    });
+  });
+  describe('change start date for today', () => {
+    it('click save, problem dialog should not appear', async () => {
+      formValues.fromDate = todayDate
+      formValues.endDate = todayDate
+      await listingCreationPage.createListingRequest(formValues)
+      expect(await transactionDialogPage.isActionCreationSummaryDisplayed()).toBeTruthy()
+      await transactionDialogPage.clickAcceptButton();
+    });
+    it('newly created hearing part should be returned from API', async () => {
+      const numberOfHearingPartsAfterAccept = (await API.getHearingParts() as any[]).length
+      expect(numberOfHearingParts + 1).toEqual(numberOfHearingPartsAfterAccept)
+    })
+  });
+});

--- a/e2e/specs/problem-list.e2e-spec.ts
+++ b/e2e/specs/problem-list.e2e-spec.ts
@@ -9,6 +9,7 @@ import { protractor } from 'protractor/built/ptor';
 import { waitFor } from '../utils/wait-for';
 import { forEachSeries } from 'p-iteration';
 import { browser } from 'protractor';
+import { Wait } from '../enums/wait';
 
 const navigationFlow = new NavigationFlow();
 const loginFlow = new LoginFlow();
@@ -71,7 +72,7 @@ describe('Problem list tests', () => {
         });
 
         it('wait until new problems will be generated', async () => {
-            const result = await waitFor(25, async () => {
+            const result = await waitFor(Wait.normal, async () => {
                 const alreadyKnownIds = problemsBeforeAction.map(problem => problem.id)
                 const problems = (await API.getProblems()) as any[]
                 newProblems = problems.filter(x => !alreadyKnownIds.includes(x.id));

--- a/e2e/specs/session.e2e-spec.ts
+++ b/e2e/specs/session.e2e-spec.ts
@@ -79,7 +79,7 @@ describe('Create Session and Listing Request, assign them despite problem, check
       numberOfVisibleEvents = await calendarPage.getNumberOfVisibleEvents()
       await navigationFlow.goToNewSessionPage()
       await sessionCreationPage.createSession(todayDate, startTime, duration, sessionType, room, judge)
-      expect(await transactionDialogPage.isSessionCreationSummaryDisplayed()).toBeTruthy()
+      expect(await transactionDialogPage.isActionCreationSummaryDisplayed()).toBeTruthy()
       await transactionDialogPage.clickAcceptButton()
     });
   });
@@ -94,7 +94,7 @@ describe('Create Session and Listing Request, assign them despite problem, check
     it('newly created listing request should be visible', async () => {
       await navigationFlow.goToNewListingRequestPage()
       await listingCreationPage.createListingRequest(listingCreationForm)
-      expect(await transactionDialogPage.isSessionCreationSummaryDisplayed()).toBeTruthy()
+      expect(await transactionDialogPage.isActionCreationSummaryDisplayed()).toBeTruthy()
       await transactionDialogPage.clickAcceptButton();
     });
   });

--- a/e2e/utils/api.ts
+++ b/e2e/utils/api.ts
@@ -57,6 +57,19 @@ export class API {
         return responseBody;
     }
 
+    static async getHearingParts() {
+        await API.login();
+        const options = {
+            method: 'GET',
+            uri: `${API.baseUrl}/hearing-part`,
+            headers: API.headers,
+            resolveWithFullResponse: true
+        }
+        const response = await rp(options)
+        const responseBody = JSON.parse(response.body)
+        return responseBody;
+    }
+
     private static async login() {
         if (API.headers.Authorization.length > 0) { return }
 

--- a/src/app/core/pipes/duration-as-minutes.pipe.ts
+++ b/src/app/core/pipes/duration-as-minutes.pipe.ts
@@ -5,6 +5,7 @@ import * as moment from 'moment';
 @Pipe({ name: 'appDurationAsMinutes' })
 export class DurationAsMinutesPipe implements PipeTransform {
     transform(duration: moment.Duration) {
+        if (!duration) { return undefined }
         return moment.duration(duration).asMinutes();
     }
 }

--- a/src/app/features/transactions/components/transaction-dialog/transaction-dialog.component.html
+++ b/src/app/features/transactions/components/transaction-dialog/transaction-dialog.component.html
@@ -8,7 +8,7 @@
     </p>
   </div>
 
-  <div id="sessionCreationSummary" fxFlex fxLayout="column" fxLayoutGap="20px" *ngIf="(transacted$ | async) && !(conflicted$ | async)">
+  <div id="actionSummary" fxFlex fxLayout="column" fxLayoutGap="20px" *ngIf="(transacted$ | async) && !(conflicted$ | async)">
     <div fxFlex>
       Action summary
     </div>
@@ -52,7 +52,7 @@
   </div>
   <div fxLayout="row" fxFlexAlign="end" fxLayoutAlign="end" mat-dialog-actions>
     <button *ngIf="(finished$ | async)" id="okButton" mat-button (click)="onOkClick()">Accept</button>
-    <button *ngIf="(finished$ | async) && (problems$ | async).length !== 0" mat-button (click)="onDeleteClick()">Rollback</button>
+    <button *ngIf="(finished$ | async) && (problems$ | async).length !== 0" id="rollbackButton" mat-button (click)="onDeleteClick()">Rollback</button>
   </div>
 
 </div>

--- a/src/app/hearing-part/actions/hearing-part.action.ts
+++ b/src/app/hearing-part/actions/hearing-part.action.ts
@@ -3,6 +3,8 @@ import { HearingPart } from '../models/hearing-part';
 import { SessionAssignment } from '../models/session-assignment';
 import { ListingCreate } from '../models/listing-create';
 import { HearingPartDeletion } from '../models/hearing-part-deletion';
+import { CreateHearingPartRequest } from '../models/create-hearing-part-request';
+import { HearingPartResponse } from '../models/hearing-part-response';
 
 export enum HearingPartActionTypes {
   GetById = '[HearingPart] Get by id',
@@ -44,7 +46,7 @@ export class GetById implements Action {
 export class SearchComplete implements Action {
   readonly type = HearingPartActionTypes.SearchComplete;
 
-  constructor(public payload: HearingPart[]) {}
+  constructor(public payload: HearingPartResponse[]) {}
 }
 
 export class SearchFailed implements Action {
@@ -62,7 +64,7 @@ export class Create implements Action {
 export class CreateListingRequest implements Action {
     readonly type = HearingPartActionTypes.CreateListingRequest;
 
-    constructor(public payload: ListingCreate) {}
+    constructor(public payload: CreateHearingPartRequest) {}
 }
 
 export class UpdateListingRequest implements Action {

--- a/src/app/hearing-part/components/hearing-parts-preview/hearing-parts-preview.component.spec.ts
+++ b/src/app/hearing-part/components/hearing-parts-preview/hearing-parts-preview.component.spec.ts
@@ -139,7 +139,7 @@ describe('HearingPartPreviewComponent', () => {
     describe('Implementation check of sortingDataAccessor on displayedColumns to sort with proper data ', () => {
         const sampleHearingPart = {
             id: '-1',
-            session: null,
+            sessionId: null,
             caseNumber: 'cn-123',
             caseTitle: 'ctitle-123',
             caseType: { code: 'ct-code', description: 'ct-description' } as CaseType,
@@ -194,7 +194,7 @@ describe('HearingPartPreviewComponent', () => {
 function generateHearingParts(id: string): HearingPartViewModel {
     return {
         id: id,
-        session: null,
+        sessionId: null,
         caseNumber: null,
         caseTitle: null,
         caseType: { code: '', description: '' } as CaseType,

--- a/src/app/hearing-part/components/hearing-parts-preview/hearing-parts-preview.component.ts
+++ b/src/app/hearing-part/components/hearing-parts-preview/hearing-parts-preview.component.ts
@@ -3,7 +3,7 @@ import { MatDialog, MatPaginator, MatSort, MatTableDataSource } from '@angular/m
 import { SessionViewModel } from '../../../sessions/models/session.viewmodel';
 import * as moment from 'moment'
 import { SelectionModel } from '@angular/cdk/collections';
-import { HearingPartViewModel, mapToHearingPart } from '../../models/hearing-part.viewmodel';
+import { HearingPartViewModel, mapToUpdateHearingPartRequest } from '../../models/hearing-part.viewmodel';
 import { NotesListDialogComponent } from '../../../notes/components/notes-list-dialog/notes-list-dialog.component';
 import { priorityValue } from '../../models/priority-model';
 import { ListingCreate } from '../../models/listing-create';
@@ -133,7 +133,7 @@ export class HearingPartsPreviewComponent implements OnInit, OnChanges {
     openEditDialog(hearingPart: HearingPartViewModel) {
         this.dialog.open(ListingCreateDialogComponent, {
             data: {
-                hearingPart: mapToHearingPart(hearingPart),
+                hearingPart: mapToUpdateHearingPartRequest(hearingPart),
                 notes: hearingPart.notes
             } as ListingCreate,
             hasBackdrop: true,

--- a/src/app/hearing-part/components/hearing-parts-preview/hearing-parts-preview.component.ts
+++ b/src/app/hearing-part/components/hearing-parts-preview/hearing-parts-preview.component.ts
@@ -90,7 +90,11 @@ export class HearingPartsPreviewComponent implements OnInit, OnChanges {
     }
 
     parseDate(date) {
-        return moment(date).format('DD/MM/YYYY');
+        if (date) {
+            return moment(date).format('DD/MM/YYYY');
+        } else {
+            return null;
+        }
     }
 
     hasNotes(hearingPart: HearingPartViewModel): boolean {

--- a/src/app/hearing-part/components/hearing-parts-preview/hearing-parts-preview.component.ts
+++ b/src/app/hearing-part/components/hearing-parts-preview/hearing-parts-preview.component.ts
@@ -137,7 +137,7 @@ export class HearingPartsPreviewComponent implements OnInit, OnChanges {
                 notes: hearingPart.notes
             } as ListingCreate,
             hasBackdrop: true,
-            height: '60%'
+            height: 'auto'
         })
     }
 

--- a/src/app/hearing-part/components/listing-create/listing-create.component.html
+++ b/src/app/hearing-part/components/listing-create/listing-create.component.html
@@ -11,11 +11,13 @@
 
                 <mat-form-field>
                     <input id="caseNumber" formControlName="caseNumber" [(ngModel)]="listing.hearingPart.caseNumber"
+                           (change)="listing.hearingPart.caseNumber = listing.hearingPart.caseNumber.trim()"
                            maxlength="{{caseNumberMaxLength}}" matInput placeholder="Case number *" type="text">
                 </mat-form-field>
 
                 <mat-form-field>
                     <input id="caseTitle" formControlName="caseTitle" [(ngModel)]="listing.hearingPart.caseTitle"
+                           (change)="listing.hearingPart.caseTitle = listing.hearingPart.caseTitle.trim()"
                            maxlength="{{caseTitleMaxLength}}" matInput placeholder="Case title" type="text" >
                 </mat-form-field>
 

--- a/src/app/hearing-part/components/listing-create/listing-create.component.html
+++ b/src/app/hearing-part/components/listing-create/listing-create.component.html
@@ -20,17 +20,17 @@
                 </mat-form-field>
 
                 <mat-form-field>
-                    <mat-select id="selectCaseType" formControlName="caseType" placeholder="Case type *"
-                                [(ngModel)]="listing.hearingPart.caseType"
+                    <mat-select id="selectCaseType" formControlName="caseTypeCode" placeholder="Case type *"
+                                [(ngModel)]="listing.hearingPart.caseTypeCode"
                                 (selectionChange)="onCaseTypeChanged($event)">
-                        <mat-option *ngFor="let case of caseTypes" selected="case.code === listing.hearingPart.caseType" [value]="case.code">{{case.description}}</mat-option>
+                        <mat-option *ngFor="let case of caseTypes" selected="case.code === listing.hearingPart.caseTypeCode" [value]="case.code">{{case.description}}</mat-option>
                     </mat-select>
                 </mat-form-field>
 
                 <mat-form-field>
-                    <mat-select id="selectHearingPart" formControlName="hearingType"
-                                placeholder="Hearing type *" [(ngModel)]="listing.hearingPart.hearingType">
-                        <mat-option *ngFor="let hearing of hearings" selected="hearing.code == listing.hearingPart.hearingType" [value]="hearing.code">{{hearing.description}}</mat-option>
+                    <mat-select id="selectHearingPart" formControlName="hearingTypeCode"
+                                placeholder="Hearing type *" [(ngModel)]="listing.hearingPart.hearingTypeCode">
+                        <mat-option *ngFor="let hearing of hearings" selected="hearing.code == listing.hearingPart.hearingTypeCode" [value]="hearing.code">{{hearing.description}}</mat-option>
                     </mat-select>
                 </mat-form-field>
 
@@ -47,7 +47,8 @@
 
                 <mat-form-field>
                     <mat-select id="communicationFacilitator" placeholder="Communication Facilitator" [(value)]="listing.hearingPart.communicationFacilitator">
-                        <mat-option *ngFor="let facilitators of communicationFacilitators" [value]="facilitators">{{facilitators}}</mat-option>
+                        <mat-option>None</mat-option>
+                        <mat-option *ngFor="let facilitators of communicationFacilitators" [value]="facilitators">{{facilitators}}</mat-option> 
                     </mat-select>
                 </mat-form-field>
 

--- a/src/app/hearing-part/components/listing-create/listing-create.component.html
+++ b/src/app/hearing-part/components/listing-create/listing-create.component.html
@@ -16,7 +16,7 @@
 
                 <mat-form-field>
                     <input id="caseTitle" formControlName="caseTitle" [(ngModel)]="listing.hearingPart.caseTitle"
-                           maxlength="{{caseTitleMaxLength}}" matInput placeholder="Case title *" type="text" >
+                           maxlength="{{caseTitleMaxLength}}" matInput placeholder="Case title" type="text" >
                 </mat-form-field>
 
                 <mat-form-field>

--- a/src/app/hearing-part/components/listing-create/listing-create.component.html
+++ b/src/app/hearing-part/components/listing-create/listing-create.component.html
@@ -23,7 +23,6 @@
                     <mat-select id="selectCaseType" formControlName="caseType" placeholder="Case type *"
                                 [(ngModel)]="listing.hearingPart.caseType"
                                 (selectionChange)="onCaseTypeChanged($event)">
-                        <mat-option>None</mat-option>
                         <mat-option *ngFor="let case of caseTypes" selected="case.code === listing.hearingPart.caseType" [value]="case.code">{{case.description}}</mat-option>
                     </mat-select>
                 </mat-form-field>
@@ -31,7 +30,6 @@
                 <mat-form-field>
                     <mat-select id="selectHearingPart" formControlName="hearingType"
                                 placeholder="Hearing type *" [(ngModel)]="listing.hearingPart.hearingType">
-                        <mat-option>None</mat-option>
                         <mat-option *ngFor="let hearing of hearings" selected="hearing.code == listing.hearingPart.hearingType" [value]="hearing.code">{{hearing.description}}</mat-option>
                     </mat-select>
                 </mat-form-field>
@@ -66,7 +64,7 @@
                         <i>Target from</i> must be before <i>Target to</i>!
                     </div>
                     <mat-form-field class="date-picker-element">
-                        <input id="fromDate" matInput [matDatepicker]="pickerStart" formControlName="targetFrom"  [(ngModel)]="listing.hearingPart.scheduleStart" placeholder="From:" re>
+                        <input id="fromDate" matInput [matDatepicker]="pickerStart" formControlName="targetFrom" [(ngModel)]="listing.hearingPart.scheduleStart" placeholder="From:" re>
                         <mat-datepicker-toggle matSuffix [for]="pickerStart"></mat-datepicker-toggle>
                         <mat-datepicker #pickerStart></mat-datepicker>
                     </mat-form-field>

--- a/src/app/hearing-part/components/listing-create/listing-create.component.spec.ts
+++ b/src/app/hearing-part/components/listing-create/listing-create.component.spec.ts
@@ -145,7 +145,7 @@ describe('ListingCreateComponent', () => {
 
     describe('Initial state ', () => {
         it('should include priority', () => {
-            expect(component.errors).toEqual('');
+            expect(component.errors).toBeUndefined();
             expect(component.listing).toBeDefined();
             expect(component.listing.hearingPart.priority).toBe(Priority.Low);
         });

--- a/src/app/hearing-part/components/listing-create/listing-create.component.spec.ts
+++ b/src/app/hearing-part/components/listing-create/listing-create.component.spec.ts
@@ -49,10 +49,8 @@ let storeSpy: jasmine.Spy;
 let component: ListingCreateComponent;
 let store: Store<State>;
 let fixture: ComponentFixture<ListingCreateComponent>;
-let listingCreateNoteConfig: ListingCreateNotesConfiguration;
 
 let note;
-let secondNote;
 
 const now = moment();
 const stubAppConfig = {getApiUrl: () => 'https://fake.url'};
@@ -67,8 +65,8 @@ const listingCreate = {
         session: undefined,
         caseNumber: 'number',
         caseTitle: 'title',
-        caseType: caseTypeWht1.code,
-        hearingType: stubHearingTypes1[0].code,
+        caseTypeCode: caseTypeWht1.code,
+        hearingTypeCode: stubHearingTypes1[0].code,
         duration: moment.duration(30, 'minute'),
         scheduleStart: now,
         scheduleEnd: now,
@@ -140,7 +138,6 @@ describe('ListingCreateComponent', () => {
         store.dispatch(new referenceDataActions.GetAllCaseTypeComplete([caseTypeWht1]));
         store.dispatch(new JudgeActions.GetComplete(stubJudges));
 
-        listingCreateNoteConfig = TestBed.get(ListingCreateNotesConfiguration);
         fixture = TestBed.createComponent(ListingCreateComponent);
         component = fixture.componentInstance;
         component.editMode = false;
@@ -185,14 +182,6 @@ describe('ListingCreateComponent', () => {
                 entityId: undefined,
                 entityType: 'e'
             } as Note;
-
-            secondNote = {
-                id: undefined,
-                content: 'a',
-                type: 't',
-                entityId: undefined,
-                entityType: 'e'
-            } as Note;
         });
 
         it('with custom inputs should dispatch proper action', () => {
@@ -208,13 +197,12 @@ describe('ListingCreateComponent', () => {
             expect(createListingAction.type).toEqual(
                 HearingPartActionTypes.CreateListingRequest
             );
-            expect(createdListing.hearingPart.id).toBeDefined();
-            expect(createdListing.hearingPart.caseNumber).toEqual('number');
-            expect(createdListing.hearingPart.caseType).toEqual('case-type-code1');
-            expect(createdListing.hearingPart.hearingType).toEqual('hearing-type-code');
-            expect(createdListing.hearingPart.scheduleStart).toEqual(now);
-            expect(createdListing.hearingPart.scheduleEnd).toEqual(now);
-            expect(createdListing.notes).toEqual([]);
+            expect(createdListing.id).toBeDefined();
+            expect(createdListing.caseNumber).toEqual('number');
+            expect(createdListing.caseTypeCode).toEqual('case-type-code1');
+            expect(createdListing.hearingTypeCode).toEqual('hearing-type-code');
+            expect(createdListing.scheduleStart).toEqual(now);
+            expect(createdListing.scheduleEnd).toEqual(now);
         });
 
         it('with default inputs should dispatch proper action', () => {
@@ -228,126 +216,72 @@ describe('ListingCreateComponent', () => {
             expect(createListingAction.type).toEqual(
                 HearingPartActionTypes.CreateListingRequest
             );
-            expect(createListingAction.payload.hearingPart).toEqual(defaultListing.hearingPart);
+            expect(createListingAction.payload).toEqual(defaultListing.hearingPart);
         });
 
-        it('with some notes it should set default notes post-creation', () => {
-            component.listing.notes = [{...note, content: 'custom content'}];
+        it('with some notes it should not changed it after post-creation', () => {
+            const expectedNotes = [{...note, content: 'custom content'}];
+            component.listing.notes = expectedNotes;
 
             component.save();
-            component.afterCreate();
 
-            expect(component.listing.notes).toEqual(
-                listingCreateNoteConfig.defaultNotes()
-            );
-
-            it('should fail when start date is after end date', () => {
-                component.listing.hearingPart.scheduleStart = moment();
-                component.listing.hearingPart.scheduleEnd = moment().subtract(10, 'day');
-                component.save();
-
-                expect(component.success).toBe(false);
-                expect(component.listing).toBeDefined();
-                expect(component.listing.hearingPart.id).not.toBeUndefined();
-
-                const createFailed = storeSpy.calls.mostRecent()
-                    .args[0] as CreateFailed;
-                expect(createFailed.type).toEqual(HearingPartActionTypes.CreateFailed);
-            });
-
-            it('If start date is undefined', () => {
-                component.listing.hearingPart.scheduleStart = undefined;
-                component.listing.hearingPart.scheduleEnd = moment();
-
-                component.save();
-
-                expect(storeSpy).toHaveBeenCalledTimes(3);
-                expect(component.errors).toEqual('');
-            });
-
-            it('If end date is undefined', () => {
-                component.listing.hearingPart.scheduleStart = moment();
-                component.listing.hearingPart.scheduleEnd = undefined;
-
-                component.save();
-
-                expect(storeSpy).toHaveBeenCalledTimes(3);
-                expect(component.errors).toEqual('');
-            });
-
-            it('should succeed when start date is before end date', () => {
-                component.listing.hearingPart.scheduleStart = moment();
-                component.listing.hearingPart.scheduleEnd = moment().add(10, 'day');
-                component.save();
-
-                const createFailed = storeSpy.calls.mostRecent()
-                    .args[0] as CreateFailed;
-                expect(createFailed.type).not.toEqual(
-                    HearingPartActionTypes.CreateFailed
-                );
-                expect(component.listing).toBeDefined();
-                expect(component.success).toBe(true);
-            });
-
-            it('should dispatch proper action', () => {
-                component.save();
-
-                expect(storeSpy).toHaveBeenCalledTimes(3);
-
-                const createListingAction = storeSpy.calls.argsFor(0)[0] as CreateListingRequest;
-
-                expect(createListingAction.type).toEqual(
-                    HearingPartActionTypes.CreateListingRequest
-                );
-            });
-
-            it('should prepare listing request with id', () => {
-                component.save();
-
-                expect(storeSpy).toHaveBeenCalledTimes(3);
-
-                const createListingAction = storeSpy.calls.argsFor(0)[0] as CreateListingRequest;
-                const createdListing = createListingAction.payload;
-
-                expect(createdListing.hearingPart.id).toBeDefined();
-            });
+            expect(component.listing.notes).toEqual(expectedNotes);
         });
 
-        describe('should prepare notes', () => {
-            let createListingAction;
-            let createdListing;
+        it('If start date is undefined', () => {
+            component.listing.hearingPart.scheduleStart = undefined;
+            component.listing.hearingPart.scheduleEnd = moment();
 
-            beforeEach(() => {
-                fixture.detectChanges();
-                spyOn(component.noteList, 'getModifiedNotes').and.callFake(() => [
-                    note,
-                    secondNote
-                ]);
+            component.save();
 
-                component.save();
+            expect(storeSpy).toHaveBeenCalledTimes(3);
+            expect(component.errors).toEqual('');
+        });
 
-                createListingAction = storeSpy.calls.argsFor(0)[0] as CreateListingRequest;
-                createdListing = createListingAction.payload;
-            });
+        it('If end date is undefined', () => {
+            component.listing.hearingPart.scheduleStart = moment();
+            component.listing.hearingPart.scheduleEnd = undefined;
 
-            it('with properly generated ids', () => {
-                expect(createdListing.notes.length).toEqual(2);
-                expect(createdListing.notes[0].id).toBeDefined();
-                expect(createdListing.notes[1].id).toBeDefined();
-                expect(createdListing.notes[0].id).not.toEqual(
-                    createdListing.notes[1].id
-                );
-            });
+            component.save();
 
-            it('with properly generated parentIds', () => {
-                expect(createdListing.notes[0].entityId).toEqual(createdListing.hearingPart.id);
-                expect(createdListing.notes[1].entityId).toEqual(createdListing.hearingPart.id);
-            });
+            expect(storeSpy).toHaveBeenCalledTimes(3);
+            expect(component.errors).toEqual('');
+        });
 
-            it('with properly generated entityType names', () => {
-                expect(createdListing.notes[0].entityType).toEqual('ListingRequest');
-                expect(createdListing.notes[1].entityType).toEqual('ListingRequest');
-            });
+        it('should succeed when start date is before end date', () => {
+            component.listing.hearingPart.scheduleStart = moment();
+            component.listing.hearingPart.scheduleEnd = moment().add(10, 'day');
+            component.save();
+
+            const createFailed = storeSpy.calls.mostRecent()
+                .args[0] as CreateFailed;
+            expect(createFailed.type).not.toEqual(
+                HearingPartActionTypes.CreateFailed
+            );
+            expect(component.listing).toBeDefined();
+        });
+
+        it('should dispatch proper action', () => {
+            component.save();
+
+            expect(storeSpy).toHaveBeenCalledTimes(3);
+
+            const createListingAction = storeSpy.calls.argsFor(0)[0] as CreateListingRequest;
+
+            expect(createListingAction.type).toEqual(
+                HearingPartActionTypes.CreateListingRequest
+            );
+        });
+
+        it('should prepare listing request with id', () => {
+            component.save();
+
+            expect(storeSpy).toHaveBeenCalledTimes(3);
+
+            const createListingAction = storeSpy.calls.argsFor(0)[0] as CreateListingRequest;
+            const createdListing = createListingAction.payload;
+
+            expect(createdListing.id).toBeDefined();
         });
 
         describe('save with edit mode', () => {

--- a/src/app/hearing-part/components/listing-create/listing-create.component.ts
+++ b/src/app/hearing-part/components/listing-create/listing-create.component.ts
@@ -89,8 +89,9 @@ export class ListingCreateComponent implements OnInit {
                 this.initiateListing();
             }
             this.setFormGroup();
-            this.initiateNotes();
         });
+
+        this.initiateNotes();
     }
 
     ngOnInit() {

--- a/src/app/hearing-part/components/listing-create/listing-create.component.ts
+++ b/src/app/hearing-part/components/listing-create/listing-create.component.ts
@@ -66,6 +66,9 @@ export class ListingCreateComponent implements OnInit {
 
     caseTitleMaxLength = 200;
     caseNumberMaxLength = 200;
+    numberOfSeconds = 60
+    binIntMaxValue = 9223372036854775807;
+    limitMaxValue = this.binIntMaxValue / this.numberOfSeconds;
 
     public listing: ListingCreate;
 
@@ -225,7 +228,7 @@ export class ListingCreateComponent implements OnInit {
             ),
             duration: new FormControl(
                 this.listing.hearingPart.duration ? this.listing.hearingPart.duration.asMinutes() : undefined,
-                [Validators.required, Validators.min(1)]
+                [Validators.required, Validators.min(1), Validators.max(this.limitMaxValue)]
             ),
             targetDates: new FormGroup({
                 targetFrom: new FormControl(this.listing.hearingPart.scheduleStart),

--- a/src/app/hearing-part/components/listing-create/listing-create.component.ts
+++ b/src/app/hearing-part/components/listing-create/listing-create.component.ts
@@ -213,7 +213,7 @@ export class ListingCreateComponent implements OnInit {
             ),
             caseTitle: new FormControl(
                 this.listing.hearingPart.caseTitle,
-                [Validators.required, Validators.maxLength(this.caseTitleMaxLength)]
+                [Validators.maxLength(this.caseTitleMaxLength)]
             ),
             caseTypeCode: new FormControl(
                 this.listing.hearingPart.caseTypeCode,

--- a/src/app/hearing-part/components/listing-create/listing-create.component.ts
+++ b/src/app/hearing-part/components/listing-create/listing-create.component.ts
@@ -79,7 +79,7 @@ export class ListingCreateComponent implements OnInit {
                 readonly listingNotesConfig: ListingCreateNotesConfiguration) {
 
         this.store.select(getHearingPartsError).subscribe((error: any) => {
-            this.errors = safe(error.message) || '';
+            this.errors = safe(() => error.message);
         });
         this.store.select(fromJudges.getJudges).withLatestFrom(
             this.store.select(fromReferenceData.selectCaseTypes)

--- a/src/app/hearing-part/components/listing-create/listing-create.component.ts
+++ b/src/app/hearing-part/components/listing-create/listing-create.component.ts
@@ -45,7 +45,7 @@ export class ListingCreateComponent implements OnInit {
     @Output() onSave = new EventEmitter();
 
     listingCreate: FormGroup;
-    communicationFacilitators = ['None', 'Sign Language', 'Interpreter', 'Digital Assistance', 'Custom'];
+    communicationFacilitators = ['Sign Language', 'Interpreter', 'Digital Assistance', 'Custom'];
     errors = '';
     priorityValues = Object.values(Priority);
     judges: Judge[] = [];
@@ -55,8 +55,10 @@ export class ListingCreateComponent implements OnInit {
     get caseTypes(): CaseType[] { return this._caseTypes }
     set caseTypes(caseTypes: CaseType[]) {
         this._caseTypes = caseTypes
-        if (safe(() => this.listing.hearingPart.caseType)) {
-            this.hearings = this.getHearingTypesFromCaseType(this.listing.hearingPart.caseType);
+        const caseTypeCode = safe(() => this.listing.hearingPart.caseTypeCode)
+
+        if (caseTypeCode) {
+            this.hearings = this.getHearingTypesFromCaseType(caseTypeCode);
         }
     }
 
@@ -102,7 +104,7 @@ export class ListingCreateComponent implements OnInit {
     }
 
     edit() {
-        this.hearingPartModificationService.updateListingRequest(this.listing, this.prepareNotes());
+        this.hearingPartModificationService.updateListingRequest(this.listing);
         this.openDialog('Editing listing request');
 
         this.onSave.emit();
@@ -111,7 +113,7 @@ export class ListingCreateComponent implements OnInit {
     create() {
         this.listing.hearingPart.id = uuid();
 
-        this.hearingPartModificationService.createListingRequest(this.listing, this.prepareNotes());
+        this.hearingPartModificationService.createListingRequest(this.listing);
         this.openDialog('Creating listing request');
     }
 
@@ -149,7 +151,7 @@ export class ListingCreateComponent implements OnInit {
     }
 
     onCaseTypeChanged(event: MatSelectChange) {
-        this.listing.hearingPart.hearingType = undefined;
+        this.listing.hearingPart.hearingTypeCode = undefined;
         let newHearings = [];
 
         if (!(event.value === undefined || event.value === null)) {
@@ -178,11 +180,10 @@ export class ListingCreateComponent implements OnInit {
         return {
             hearingPart: {
                 id: undefined,
-                session: undefined,
                 caseNumber: undefined,
                 caseTitle: undefined,
-                caseType: undefined,
-                hearingType: undefined,
+                caseTypeCode: undefined,
+                hearingTypeCode: undefined,
                 duration: undefined,
                 scheduleStart: undefined,
                 scheduleEnd: undefined,
@@ -193,7 +194,6 @@ export class ListingCreateComponent implements OnInit {
                 userTransactionId: undefined,
             },
             notes: this.listingNotesConfig.defaultNotes(),
-            userTransactionId: undefined
         };
     }
 
@@ -207,12 +207,12 @@ export class ListingCreateComponent implements OnInit {
                 this.listing.hearingPart.caseTitle,
                 [Validators.required, Validators.maxLength(this.caseTitleMaxLength)]
             ),
-            caseType: new FormControl(
-                this.listing.hearingPart.caseType,
+            caseTypeCode: new FormControl(
+                this.listing.hearingPart.caseTypeCode,
                 [Validators.required]
             ),
-            hearingType: new FormControl(
-                this.listing.hearingPart.hearingType,
+            hearingTypeCode: new FormControl(
+                this.listing.hearingPart.hearingTypeCode,
                 [Validators.required]
             ),
             duration: new FormControl(

--- a/src/app/hearing-part/effects/listing-create.effects.ts
+++ b/src/app/hearing-part/effects/listing-create.effects.ts
@@ -19,8 +19,7 @@ export class ListingCreateEffects {
     create$: Observable<Action> = this.actions$.pipe(
         ofType<CreateListingRequest>(HearingPartActionTypes.CreateListingRequest),
         mergeMap(action =>
-            this.hearingPartService.createListing({...action.payload.hearingPart,
-                userTransactionId: action.payload.userTransactionId}).pipe(
+            this.hearingPartService.createListing(action.payload).pipe(
                 mergeMap((transaction: Transaction) => [new transactionActions.UpdateTransaction(transaction)]),
                 catchError((err: HttpErrorResponse) => of(new CreateFailed(err.error)))
             )
@@ -31,11 +30,10 @@ export class ListingCreateEffects {
     update$: Observable<Action> = this.actions$.pipe(
         ofType<UpdateListingRequest>(HearingPartActionTypes.UpdateListingRequest),
         mergeMap(action =>
-            this.hearingPartService.updateListing({...action.payload.hearingPart,
-                userTransactionId: action.payload.userTransactionId}).pipe(
+            this.hearingPartService.updateListing(action.payload.hearingPart).pipe(
                 mergeMap((transaction: Transaction) => [new transactionActions.UpdateTransaction(transaction)]),
                 catchError((err: any) => of(new transactionActions.TransactionFailure(
-                    {err: err, id: action.payload.userTransactionId}))
+                    {err: err, id: action.payload.hearingPart.userTransactionId}))
                 )
             )
         )

--- a/src/app/hearing-part/models/create-hearing-part-request.ts
+++ b/src/app/hearing-part/models/create-hearing-part-request.ts
@@ -1,0 +1,17 @@
+import * as moment from 'moment'
+import { Priority } from './priority-model';
+
+export interface CreateHearingPartRequest {
+    id: string;
+    caseNumber: string;
+    caseTitle: string;
+    caseTypeCode: string;
+    hearingTypeCode: string;
+    duration: moment.Duration
+    scheduleStart: moment.Moment;
+    scheduleEnd: moment.Moment;
+    priority: Priority;
+    reservedJudgeId: string;
+    communicationFacilitator: string;
+    userTransactionId: string;
+}

--- a/src/app/hearing-part/models/hearing-part-response.ts
+++ b/src/app/hearing-part/models/hearing-part-response.ts
@@ -1,0 +1,16 @@
+export interface HearingPartResponse {
+    id: string;
+    caseNumber: string;
+    caseTitle: string;
+    caseTypeCode: string;
+    hearingTypeCode: string;
+    duration: string;
+    scheduleStart: string;
+    scheduleEnd: string;
+    priority: string;
+    reservedJudgeId: string;
+    communicationFacilitator: string;
+    deleted: boolean;
+    sessionId?: string;
+    version: number;
+}

--- a/src/app/hearing-part/models/hearing-part.ts
+++ b/src/app/hearing-part/models/hearing-part.ts
@@ -1,19 +1,3 @@
-import * as moment from 'moment'
-import { Priority } from './priority-model';
+import { HearingPartResponse } from './hearing-part-response';
 
-export interface HearingPart {
-    id: string;
-    session: string;
-    caseNumber: string;
-    caseTitle: string;
-    caseType: string;
-    hearingType: string;
-    duration: moment.Duration
-    scheduleStart: moment.Moment;
-    scheduleEnd: moment.Moment;
-    version: number;
-    priority: Priority;
-    reservedJudgeId: string;
-    communicationFacilitator: string;
-    userTransactionId: string;
-}
+export interface HearingPart extends HearingPartResponse { }

--- a/src/app/hearing-part/models/hearing-part.viewmodel.ts
+++ b/src/app/hearing-part/models/hearing-part.viewmodel.ts
@@ -1,14 +1,14 @@
+import { UpdateHearingPartRequest } from './update-hearing-part-request';
 import * as moment from 'moment'
 import { Note } from '../../notes/models/note.model';
 import { Priority } from './priority-model';
 import { Judge } from '../../judges/models/judge.model';
 import { HearingType } from '../../core/reference/models/hearing-type';
 import { CaseType } from '../../core/reference/models/case-type';
-import { HearingPart } from './hearing-part';
 
 export interface HearingPartViewModel {
     id: string;
-    session: string;
+    sessionId: string;
     caseNumber: string;
     caseTitle: string;
     caseType: CaseType;
@@ -24,20 +24,20 @@ export interface HearingPartViewModel {
     reservedJudgeId: string;
 }
 
-export function mapToHearingPart(hpvm: HearingPartViewModel) {
+export function mapToUpdateHearingPartRequest(hpvm: HearingPartViewModel): UpdateHearingPartRequest {
     return {
         id: hpvm.id,
-        session: hpvm.session,
         caseNumber: hpvm.caseNumber,
         caseTitle: hpvm.caseTitle,
-        caseType: hpvm.caseType.code,
-        hearingType: hpvm.hearingType.code,
+        caseTypeCode: hpvm.caseType.code,
+        hearingTypeCode: hpvm.hearingType.code,
         duration: hpvm.duration,
         scheduleStart: hpvm.scheduleStart,
         scheduleEnd: hpvm.scheduleEnd,
         version: hpvm.version,
         priority: hpvm.priority,
         reservedJudgeId: hpvm.reservedJudgeId,
-        communicationFacilitator: hpvm.communicationFacilitator
-    } as HearingPart
+        communicationFacilitator: hpvm.communicationFacilitator,
+        userTransactionId: undefined
+    }
 }

--- a/src/app/hearing-part/models/listing-create.ts
+++ b/src/app/hearing-part/models/listing-create.ts
@@ -1,8 +1,7 @@
+import { UpdateHearingPartRequest } from './update-hearing-part-request';
 import { Note } from '../../notes/models/note.model';
-import { HearingPart } from './hearing-part';
 
 export interface ListingCreate {
-    hearingPart: HearingPart;
+    hearingPart: UpdateHearingPartRequest;
     notes: Note[]
-    userTransactionId: string;
 }

--- a/src/app/hearing-part/models/update-hearing-part-request.ts
+++ b/src/app/hearing-part/models/update-hearing-part-request.ts
@@ -1,0 +1,5 @@
+import { CreateHearingPartRequest } from './create-hearing-part-request';
+
+export interface UpdateHearingPartRequest extends CreateHearingPartRequest {
+    version: number;
+}

--- a/src/app/hearing-part/reducers/hearing-part.reducer.spec.ts
+++ b/src/app/hearing-part/reducers/hearing-part.reducer.spec.ts
@@ -40,11 +40,11 @@ function stateWith(hearingPartReducer): State {
 function generateHearingParts(id: string): HearingPart {
     return {
         id: id,
-        session: null,
+        sessionId: null,
         caseNumber: null,
         caseTitle: null,
-        caseType: null,
-        hearingType: null,
+        caseTypeCode: null,
+        hearingTypeCode: null,
         duration: null,
         scheduleStart: null,
         scheduleEnd: null,
@@ -52,6 +52,6 @@ function generateHearingParts(id: string): HearingPart {
         priority: null,
         reservedJudgeId: null,
         communicationFacilitator: null,
-        userTransactionId: null
+        deleted: false
     }
 };

--- a/src/app/hearing-part/reducers/index.ts
+++ b/src/app/hearing-part/reducers/index.ts
@@ -47,14 +47,16 @@ export const getFullHearingParts = createSelector(getAllHearingParts, getNotes, 
         finalHearingParts = hearingParts.map((hearingPart: HearingPart) => {
             const {id, sessionId, caseNumber, caseTitle, duration, priority,
                 scheduleStart, scheduleEnd, version, reservedJudgeId, communicationFacilitator} = hearingPart
+                const scheduleStartObj = moment(scheduleStart)
+                const scheduleEndObj = moment(scheduleEnd)
             return {
                 id,
                 sessionId,
                 caseNumber,
                 caseTitle,
                 duration: moment.duration(duration),
-                scheduleStart: moment(scheduleStart),
-                scheduleEnd: moment(scheduleEnd),
+                scheduleStart: scheduleStartObj.isValid() ? scheduleStartObj : undefined,
+                scheduleEnd: scheduleEndObj.isValid() ? scheduleEndObj : undefined,
                 version,
                 reservedJudgeId,
                 communicationFacilitator,

--- a/src/app/hearing-part/reducers/index.ts
+++ b/src/app/hearing-part/reducers/index.ts
@@ -6,6 +6,8 @@ import { getNotes } from '../../notes/reducers';
 import { HearingPartViewModel } from '../models/hearing-part.viewmodel';
 import { HearingPart } from '../models/hearing-part';
 import { getJudgesEntities } from '../../judges/reducers';
+import * as moment from 'moment';
+import { Priority } from '../models/priority-model';
 
 export interface HearingPartsState {
     readonly hearingParts: fromHearingParts.State;
@@ -43,10 +45,22 @@ export const getFullHearingParts = createSelector(getAllHearingParts, getNotes, 
         let finalHearingParts: HearingPartViewModel[];
         if (hearingParts === undefined) { return []; }
         finalHearingParts = hearingParts.map((hearingPart: HearingPart) => {
+            const {id, sessionId, caseNumber, caseTitle, duration, priority,
+                scheduleStart, scheduleEnd, version, reservedJudgeId, communicationFacilitator} = hearingPart
             return {
-                ...hearingPart,
-                caseType: caseTypes[hearingPart.caseType],
-                hearingType: hearingTypes[hearingPart.hearingType],
+                id,
+                sessionId,
+                caseNumber,
+                caseTitle,
+                duration: moment.duration(duration),
+                scheduleStart: moment(scheduleStart),
+                scheduleEnd: moment(scheduleEnd),
+                version,
+                reservedJudgeId,
+                communicationFacilitator,
+                priority: Priority[priority],
+                caseType: caseTypes[hearingPart.caseTypeCode],
+                hearingType: hearingTypes[hearingPart.hearingTypeCode],
                 reservedJudge: judges[hearingPart.reservedJudgeId],
                 notes: Object.values(notes).filter(note => note.entityId === hearingPart.id),
             };

--- a/src/app/hearing-part/services/hearing-part-modification-service.ts
+++ b/src/app/hearing-part/services/hearing-part-modification-service.ts
@@ -6,7 +6,6 @@ import { AssignToSession, CreateListingRequest, Delete, DeleteComplete, UpdateLi
 import { InitializeTransaction } from '../../features/transactions/actions/transaction.action';
 import { EntityTransaction } from '../../features/transactions/models/transaction-status.model';
 import * as ProblemsActions from '../../problems/actions/problem.action';
-import { Note } from '../../notes/models/note.model';
 import { ListingCreate } from '../models/listing-create';
 import { v4 as uuid } from 'uuid';
 import { HearingPartDeletion } from '../models/hearing-part-deletion';
@@ -22,20 +21,26 @@ export class HearingPartModificationService {
         this.store.dispatch(new InitializeTransaction(this.createTransaction(assignment.sessionId, assignment.userTransactionId)))
     }
 
-    createListingRequest(listing: ListingCreate, notes: Note[]) {
-        listing.userTransactionId = uuid();
+    createListingRequest(listing: ListingCreate) {
+        listing.hearingPart.userTransactionId = uuid();
 
-        this.store.dispatch(new CreateListingRequest({...listing, notes: notes}));
+        this.store.dispatch(new CreateListingRequest(listing.hearingPart));
         this.store.dispatch(new ProblemsActions.RemoveAll());
-        this.store.dispatch(new InitializeTransaction(this.createTransaction(listing.hearingPart.id, listing.userTransactionId)))
+        this.store.dispatch(new InitializeTransaction(
+                this.createTransaction(listing.hearingPart.id, listing.hearingPart.userTransactionId)
+            )
+        )
     }
 
-    updateListingRequest(listing: ListingCreate, notes: Note[]) {
-        listing.userTransactionId = uuid();
+    updateListingRequest(listing: ListingCreate) {
+        listing.hearingPart.userTransactionId = uuid();
 
-        this.store.dispatch(new UpdateListingRequest({...listing, notes: notes}));
+        this.store.dispatch(new UpdateListingRequest(listing));
         this.store.dispatch(new ProblemsActions.RemoveAll());
-        this.store.dispatch(new InitializeTransaction(this.createTransaction(listing.hearingPart.id, listing.userTransactionId)))
+        this.store.dispatch(new InitializeTransaction(
+                this.createTransaction(listing.hearingPart.id, listing.hearingPart.userTransactionId)
+            )
+        )
     }
 
     deleteHearingPart(hearingPartDeletion: HearingPartDeletion) {

--- a/src/app/hearing-part/services/hearing-part-service.spec.ts
+++ b/src/app/hearing-part/services/hearing-part-service.spec.ts
@@ -1,31 +1,32 @@
+import { HearingPartResponse } from './../models/hearing-part-response';
+import { UpdateHearingPartRequest } from './../models/update-hearing-part-request';
+import { CreateHearingPartRequest } from './../models/create-hearing-part-request';
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { AppConfig } from '../../app.config';
 import { HearingPartService } from './hearing-part-service';
 import moment = require('moment');
-import { HearingPart } from '../models/hearing-part';
+import { v4 as uuid } from 'uuid';
 
 const mockedAppConfig = { getApiUrl: () => 'https://google.co.uk' };
 
 let hearingPartService: HearingPartService;
 let httpMock: HttpTestingController;
 
-const hearingPartResponse = {
+const hearingPartResponse: HearingPartResponse = {
     version: 2,
     id: 'ba766510-e898-4919-8d3b-25f3e1b932aa',
     caseNumber: 'number-2018-08-27T09:55:24.172Z',
     caseTitle: 'title-2018-08-27T09:55:24.172Z',
-    caseType: 'SCLAIMS',
-    hearingType: 'Preliminary Hearing',
+    caseTypeCode: 'SCLAIMS',
+    hearingTypeCode: 'Preliminary Hearing',
     duration: 'PT30M',
     scheduleStart: '2018-08-27T09:55:24.172Z',
     scheduleEnd: '2018-09-26T09:55:24.174Z',
     reservedJudgeId: null,
     communicationFacilitator: null,
-    start: null,
-    createdAt: '2018-08-27T10:40:48.824Z',
     priority: null,
-    session: null,
+    deleted: false
 };
 
 const normalizedHearingPartsResponse = {
@@ -38,9 +39,9 @@ const normalizedHearingPartsResponse = {
                 caseTitle: 'title-2018-08-27T09:55:24.172Z',
                 caseType: 'SCLAIMS',
                 hearingType: 'Preliminary Hearing',
-                duration: moment.duration('PT30M'),
-                scheduleStart: moment('2018-08-27T09:55:24.172Z'),
-                scheduleEnd: moment('2018-09-26T09:55:24.174Z'),
+                duration: 'PT30M',
+                scheduleStart: '2018-08-27T09:55:24.172Z',
+                scheduleEnd: '2018-09-26T09:55:24.174Z',
                 reservedJudgeId: null,
                 communicationFacilitator: null,
                 start: null,
@@ -63,9 +64,9 @@ const normalizedHearingPartResponse = {
                 caseTitle: 'title-2018-08-27T09:55:24.172Z',
                 caseType: 'SCLAIMS',
                 hearingType: 'Preliminary Hearing',
-                duration: moment.duration('PT30M'),
-                scheduleStart: moment('2018-08-27T09:55:24.172Z'),
-                scheduleEnd: moment('2018-09-26T09:55:24.174Z'),
+                duration: 'PT30M',
+                scheduleStart: '2018-08-27T09:55:24.172Z',
+                scheduleEnd: '2018-09-26T09:55:24.174Z',
                 reservedJudgeId: null,
                 communicationFacilitator: null,
                 start: null,
@@ -89,24 +90,25 @@ const sessionAssignment = {
 
 const hearingParts = [hearingPartResponse];
 
-const hearingPart = {
-    version: 2,
+const createHearingPartRequest: CreateHearingPartRequest = {
     id: 'ba766510-e898-4919-8d3b-25f3e1b932aa',
     caseNumber: 'number-2018-08-27T09:55:24.172Z',
     caseTitle: 'title-2018-08-27T09:55:24.172Z',
-    caseType: 'SCLAIMS',
-    hearingType: 'Preliminary Hearing',
+    caseTypeCode: 'SCLAIMS',
+    hearingTypeCode: 'Preliminary Hearing',
     duration: moment.duration('PT30M'),
     scheduleStart: moment('2018-08-27T09:55:24.172Z'),
     scheduleEnd: moment('2018-09-26T09:55:24.174Z'),
     reservedJudgeId: null,
     communicationFacilitator: null,
-    start: null,
-    createdAt: '2018-08-27T10:40:48.824Z',
     priority: null,
-    session: null,
-    userTransactionId: null
-} as HearingPart;
+    userTransactionId: uuid()
+};
+
+const updateHearingPartRequest: UpdateHearingPartRequest = {
+    ...createHearingPartRequest,
+    version: 1
+};
 
 describe('HearingPartService', () => {
     beforeEach(() => {
@@ -172,7 +174,7 @@ describe('HearingPartService', () => {
         const expectedUrl = `${mockedAppConfig.getApiUrl()}/hearing-part/create`;
 
         it('should build proper url', () => {
-            hearingPartService.createListing(hearingPart).subscribe();
+            hearingPartService.createListing(createHearingPartRequest).subscribe();
 
             httpMock.expectOne(expectedUrl).flush(hearingPartResponse);
         });
@@ -182,7 +184,7 @@ describe('HearingPartService', () => {
         const expectedUrl = `${mockedAppConfig.getApiUrl()}/hearing-part/update`;
 
         it('should build proper url', () => {
-            hearingPartService.updateListing(hearingPart).subscribe();
+            hearingPartService.updateListing(updateHearingPartRequest).subscribe();
 
             httpMock.expectOne(expectedUrl).flush(hearingPartResponse);
         });

--- a/src/app/hearing-part/services/hearing-part-service.ts
+++ b/src/app/hearing-part/services/hearing-part-service.ts
@@ -1,15 +1,16 @@
+import { CreateHearingPartRequest } from '../models/create-hearing-part-request';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { AppConfig } from '../../app.config';
 import { SessionAssignment } from '../models/session-assignment';
-import { HearingPart } from '../models/hearing-part';
 import { map } from 'rxjs/operators';
 import { hearingPart, hearingParts } from '../../core/schemas/data.schema';
 import { normalize } from 'normalizr';
-import * as moment from 'moment';
 import { Transaction } from '../../features/transactions/services/transaction-backend.service';
 import { HearingPartDeletion } from '../models/hearing-part-deletion';
+import { UpdateHearingPartRequest } from '../models/update-hearing-part-request';
+import { HearingPartResponse } from '../models/hearing-part-response';
 
 @Injectable()
 export class HearingPartService {
@@ -18,45 +19,31 @@ export class HearingPartService {
 
     searchHearingParts(params): Observable<any> {
         return this.http
-            .get<HearingPart[]>(`${this.config.getApiUrl()}/hearing-part`, {
+            .get<HearingPartResponse[]>(`${this.config.getApiUrl()}/hearing-part`, {
               params: new HttpParams({ fromObject: params })
-            })
-          .pipe(map(data => data.map(hp => {
-                  hp.scheduleEnd = (hp.scheduleEnd === null) ? null : moment(hp.scheduleEnd);
-                  hp.scheduleStart = (hp.scheduleStart === null) ? null : moment(hp.scheduleStart);
-                  hp.duration  = (hp.duration === null) ? null : moment.duration(hp.duration);
-              return hp;
-          })),
-              map(data => {return normalize(data, hearingParts)}));
-
+            }).pipe(map(data => {return normalize(data, hearingParts)}))
     }
 
     getById(id: string): Observable<any> {
         return this.http
-            .get<HearingPart>(`${this.config.getApiUrl()}/hearing-part/${id}`)
-                .pipe(map(hp => {
-                    hp.scheduleEnd = moment(hp.scheduleEnd);
-                    hp.scheduleStart = moment(hp.scheduleStart);
-                    hp.duration = moment.duration(hp.duration);
-                    return hp;
-                }), map(data => {return normalize(data, hearingPart)}));
-
+            .get<HearingPartResponse>(`${this.config.getApiUrl()}/hearing-part/${id}`)
+                .pipe(map(data => {return normalize(data, hearingPart)}));
     }
 
     assignToSession(query: SessionAssignment): Observable<any> {
         return this.http
-            .put<HearingPart>(`${this.config.getApiUrl()}/hearing-part/${query.hearingPartId}`,
+            .put<HearingPartResponse>(`${this.config.getApiUrl()}/hearing-part/${query.hearingPartId}`,
                 query);
     }
 
-    createListing(query: HearingPart): Observable<Transaction> {
+    createListing(query: CreateHearingPartRequest): Observable<Transaction> {
         return this.http
             .put<Transaction>(`${this.config.getApiUrl()}/hearing-part/create`, JSON.stringify(query), {
                 headers: {'Content-Type': 'application/json'}
             });
     }
 
-    updateListing(query: HearingPart): Observable<Transaction> {
+    updateListing(query: UpdateHearingPartRequest): Observable<Transaction> {
         return this.http
             .put<Transaction>(`${this.config.getApiUrl()}/hearing-part/update`, JSON.stringify(query), {
                 headers: {'Content-Type': 'application/json'}

--- a/src/app/notes/services/notes.service.ts
+++ b/src/app/notes/services/notes.service.ts
@@ -22,6 +22,7 @@ export class NotesService {
             .post<Note[]>(`${this.getUrl()}/entities`, ids)
             .pipe(map(notes => notes || []))
     }
+
     createMany(notes: Note[]): Observable<Note[]> {
         return this.http
             .put<Note[]>(this.getUrl(), notes)

--- a/src/app/sessions/containers/sessions-listings-search/sessions-listings-search.component.spec.ts
+++ b/src/app/sessions/containers/sessions-listings-search/sessions-listings-search.component.spec.ts
@@ -31,19 +31,20 @@ import { TransactionDialogComponent } from '../../../features/transactions/compo
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
 import * as notesActions from '../../../notes/actions/notes.action';
 import { Note } from '../../../notes/models/note.model';
-import { HearingPartViewModel, mapToHearingPart } from '../../../hearing-part/models/hearing-part.viewmodel';
+import { HearingPartViewModel } from '../../../hearing-part/models/hearing-part.viewmodel';
 import { Priority } from '../../../hearing-part/models/priority-model';
 import { CaseType } from '../../../core/reference/models/case-type';
-import { HearingPart } from '../../../hearing-part/models/hearing-part';
 import { HearingType } from '../../../core/reference/models/hearing-type';
 import { SessionType } from '../../../core/reference/models/session-type';
 import { SessionsFilterService } from '../../services/sessions-filter-service';
+import { HearingPartResponse } from '../../../hearing-part/models/hearing-part-response';
 
 let storeSpy: jasmine.Spy;
 let component: SessionsListingsSearchComponent;
 let store: Store<fromHearingParts.State>;
 let mockedFullSession: SessionViewModel[];
 const nowMoment = moment();
+const nowISOSting = nowMoment.toISOString();
 const roomId = 'some-room-id';
 const judgeId = 'some-judge-id';
 const stubCaseType = {code: 'some-case-type-code', description: 'some-case-type'} as CaseType;
@@ -52,10 +53,11 @@ const stubSessionType = {code: 'some-session-type-code', description: 'some-sess
 const stubSessionTypes = [stubSessionType];
 const stubHearingType = {code: 'some-hearing-type-code', description: 'some-hearing-type'} as HearingType;
 const stubHearingTypes = [stubHearingType];
-const sessionDuration = 30;
-const overListedDuration = 31;
-const notListedDuration = 0;
-const customDuration = 16;
+const durationStringFormat = 'PT30M';
+const sessionDuration = moment.duration(durationStringFormat).asMilliseconds();
+const overListedDuration = moment.duration('PT31M').asMilliseconds();
+const notListedDuration = moment.duration('PT0M').asMilliseconds();
+const customDuration = moment.duration('PT16M').asMilliseconds();
 const mockedRooms: Room[] = [{ id: roomId, name: 'some-room-name', roomTypeCode: 'code' }];
 const mockedJudges: Judge[] = [{ id: judgeId, name: 'some-judge-name' }];
 const mockedNotes: Note[] = [
@@ -67,16 +69,33 @@ const mockedNotes: Note[] = [
         entityType: 'ListingRequest'
     }];
 
+const mockedHearingPartResponse: HearingPartResponse = {
+  id: 'some-id',
+  sessionId: undefined,
+  caseNumber: 'abc123',
+  caseTitle: 'some-case-title',
+  caseTypeCode: stubCaseType.code,
+  hearingTypeCode: stubHearingType.code,
+  duration: durationStringFormat,
+  scheduleStart: nowISOSting,
+  scheduleEnd: nowISOSting,
+  version: 2,
+  priority: Priority.Low,
+  reservedJudgeId: judgeId,
+  communicationFacilitator: 'interpreter',
+  deleted: false
+}
+
 const mockedUnlistedHearingPartVM: HearingPartViewModel = {
     id: 'some-id',
-    session: undefined,
+    sessionId: undefined,
     caseNumber: 'abc123',
     caseTitle: 'some-case-title',
     caseType: stubCaseType,
     hearingType: stubHearingType,
-    duration: moment.duration(sessionDuration),
-    scheduleStart: nowMoment,
-    scheduleEnd: nowMoment,
+    duration: moment.duration(durationStringFormat),
+    scheduleStart: moment(nowISOSting),
+    scheduleEnd: moment(nowISOSting),
     version: 2,
     priority: Priority.Low,
     reservedJudgeId: judgeId,
@@ -85,18 +104,11 @@ const mockedUnlistedHearingPartVM: HearingPartViewModel = {
     reservedJudge: mockedJudges[0]
 };
 
-const mockedUnlistedHearingPart: HearingPart = {
-    ...mapToHearingPart(mockedUnlistedHearingPartVM),
-};
-
-const mockedUnlistedHearingPartsVM: HearingPartViewModel[] = [mockedUnlistedHearingPartVM];
-const mockedUnlistedHearingParts: HearingPart[] = [mockedUnlistedHearingPart];
-
 // same as unlisted, but with session set to matching id in Session
-let mockedListedHearingPartVM = { ...mockedUnlistedHearingPartVM, session: 'some-session-id' };
-let mockedListedHearingPart = { ...mockedUnlistedHearingPart, session: 'some-session-id' };
+let mockedListedHearingPartVM: HearingPartViewModel = { ...mockedUnlistedHearingPartVM, sessionId: 'some-session-id' };
+let mockedListedHearingPart: HearingPartResponse = { ...mockedHearingPartResponse, sessionId: 'some-session-id' };
 const mockedListedHearingPartsVM: HearingPartViewModel[] = [mockedListedHearingPartVM];
-const mockedListedHearingParts: HearingPart[] = [mockedListedHearingPart];
+const mockedListedHearingPartResponses: HearingPartResponse[] = [mockedListedHearingPart];
 
 const mockedSessions: Session[] = [
   {
@@ -153,12 +165,12 @@ describe('SessionsListingsSearchComponent', () => {
     it('should fetch hearingParts', () => {
       store.dispatch(new referenceDataActions.GetAllCaseTypeComplete(stubCaseTypes));
       store.dispatch(new referenceDataActions.GetAllHearingTypeComplete(stubHearingTypes));
-      store.dispatch(new hearingPartActions.SearchComplete(mockedUnlistedHearingParts));
+      store.dispatch(new hearingPartActions.SearchComplete([mockedHearingPartResponse]));
       store.dispatch(new notesActions.UpsertMany(mockedNotes));
       store.dispatch(new judgeActions.GetComplete(mockedJudges));
 
       component.hearingParts$.subscribe(hearingParts => {
-        expect(hearingParts).toEqual(mockedUnlistedHearingPartsVM);
+        expect(hearingParts).toEqual([mockedUnlistedHearingPartVM]);
       });
     });
     it('should fetch rooms', () => {
@@ -178,7 +190,7 @@ describe('SessionsListingsSearchComponent', () => {
       store.dispatch(new referenceDataActions.GetAllHearingTypeComplete(stubHearingTypes));
       store.dispatch(new referenceDataActions.GetAllSessionTypeComplete(stubSessionTypes));
       store.dispatch(new notesActions.UpsertMany(mockedNotes));
-      store.dispatch(new hearingPartActions.SearchComplete(mockedListedHearingParts));
+      store.dispatch(new hearingPartActions.SearchComplete(mockedListedHearingPartResponses));
       store.dispatch(new roomActions.GetComplete(mockedRooms));
       store.dispatch(new judgeActions.GetComplete(mockedJudges));
       store.dispatch(new sessionsActions.SearchComplete(mockedSessions));
@@ -192,10 +204,10 @@ describe('SessionsListingsSearchComponent', () => {
       expect(component.endDate).toBeDefined();
     });
     it('should set null to selectedHearingPart', () => {
-      expect(component.selectedHearingPart).toEqual({});
+      expect(component.selectedHearingPart).toBeUndefined();
     });
     it('should set selectedSession to empty obj', () => {
-      expect(component.selectedSession).toEqual({});
+      expect(component.selectedSession).toBeUndefined();
     });
   });
 
@@ -319,7 +331,7 @@ describe('SessionsListingsSearchComponent', () => {
   describe('assignToSession', () => {
     it('should dispatch AssignToSession action', () => {
       component.selectedSession = mockedFullSession[0];
-      component.selectedHearingPart = mockedUnlistedHearingPart;
+      component.selectedHearingPart = mockedListedHearingPartVM;
       component.assignToSession();
 
       const passedObj = storeSpy.calls.first().args[0];
@@ -329,10 +341,10 @@ describe('SessionsListingsSearchComponent', () => {
         passedObj instanceof hearingPartActions.AssignToSession
       ).toBeTruthy();
       expect(sessionAssignmentPayload.hearingPartId).toEqual(
-        mockedUnlistedHearingPart.id
+        mockedListedHearingPartVM.id
       );
       expect(sessionAssignmentPayload.hearingPartVersion).toEqual(
-          mockedUnlistedHearingPart.version
+        mockedListedHearingPartVM.version
       );
       expect(sessionAssignmentPayload.userTransactionId).toBeDefined();
       expect(sessionAssignmentPayload.sessionId).toEqual(
@@ -348,7 +360,7 @@ describe('SessionsListingsSearchComponent', () => {
   describe('selectSession', () => {
     it('should set selectSession', () => {
       const expectedSelectedSession = mockedFullSession[0];
-      expect(component.selectedSession).toEqual({});
+      expect(component.selectedSession).toBeUndefined();
       component.selectSession(expectedSelectedSession);
       expect(component.selectedSession).toEqual(expectedSelectedSession);
     });
@@ -358,19 +370,19 @@ describe('SessionsListingsSearchComponent', () => {
     describe('when selectedHearingPart is not null and selectedSession is set', () => {
       it('should return true ', () => {
         component.selectedSession = mockedFullSession[0];
-        component.selectedHearingPart = mockedUnlistedHearingPart;
+        component.selectedHearingPart = mockedUnlistedHearingPartVM;
         expect(component.assignButtonEnabled()).toEqual(true);
       });
     });
     describe('when either selectedHearingPart is not null or selectedSession is not set', () => {
       it('should return false ', () => {
-        component.selectedSession = {};
-        component.selectedHearingPart = mockedUnlistedHearingPart;
+        component.selectedSession = undefined;
+        component.selectedHearingPart = mockedUnlistedHearingPartVM;
         expect(component.assignButtonEnabled()).toEqual(false);
       });
       it('should return false ', () => {
-        component.selectedSession = {};
-        component.selectedHearingPart = {};
+        component.selectedSession = undefined;
+        component.selectedHearingPart = undefined;
         expect(component.assignButtonEnabled()).toEqual(false);
       });
     });
@@ -413,7 +425,7 @@ function defaultFullMockedSession(): SessionViewModel {
     hearingParts: mockedListedHearingPartsVM,
     jurisdiction: 'some jurisdiction',
     version: 1,
-    allocated: moment.duration('PT0.03S'),
+    allocated: moment.duration('PT30M'),
     utilization: 100,
     available: moment.duration('PT0M')
   };

--- a/src/app/sessions/containers/sessions-listings-search/sessions-listings-search.component.ts
+++ b/src/app/sessions/containers/sessions-listings-search/sessions-listings-search.component.ts
@@ -27,6 +27,7 @@ import { asArray } from '../../../utils/array-utils';
 import { HearingPartViewModel } from '../../../hearing-part/models/hearing-part.viewmodel';
 import { SessionType } from '../../../core/reference/models/session-type';
 import { SessionsFilterService } from '../../services/sessions-filter-service';
+import { safe } from '../../../utils/js-extensions';
 
 @Component({
     selector: 'app-sessions-listings-search',
@@ -41,8 +42,8 @@ export class SessionsListingsSearchComponent implements OnInit {
     sessions$: Observable<SessionViewModel[]>;
     rooms$: Observable<Room[]>;
     judges$: Observable<Judge[]>;
-    selectedSession: any;
-    selectedHearingPart;
+    selectedSession: SessionViewModel;
+    selectedHearingPart: HearingPartViewModel;
     filters$ = new Subject<SessionFilters>();
     sessionTypes$: Observable<SessionType[]>;
     filteredSessions: SessionViewModel[];
@@ -64,8 +65,6 @@ export class SessionsListingsSearchComponent implements OnInit {
         this.sessions$ = this.store.pipe(select(fromSessions.getFullSessions));
         this.startDate = moment();
         this.endDate = moment().add(5, 'years');
-        this.selectedHearingPart = {};
-        this.selectedSession = {};
 
         combineLatest(this.sessions$, this.filters$, this.filterSessions).subscribe((data) => { this.filteredSessions = data});
     }
@@ -109,6 +108,8 @@ export class SessionsListingsSearchComponent implements OnInit {
 
         this.openSummaryDialog().afterClosed().subscribe(() => {
             this.store.dispatch(new fromHearingPartsActions.Search());
+            this.selectedHearingPart = undefined
+            this.selectedSession = undefined
         });
     }
 
@@ -117,7 +118,7 @@ export class SessionsListingsSearchComponent implements OnInit {
     }
 
     assignButtonEnabled() {
-        return !!((this.selectedHearingPart.id) && (this.selectedSession.id));
+        return !!(safe(() => this.selectedHearingPart.id) && (safe(() => this.selectedSession.id)));
     }
 
     private openSummaryDialog() {

--- a/src/app/sessions/reducers/index.ts
+++ b/src/app/sessions/reducers/index.ts
@@ -89,7 +89,7 @@ export const getFullSessions = createSelector(
         if (sessions === undefined) {return []}
         finalSessions = Object.keys(sessions).map(sessionKey => {
             const sessionData: Session = sessions[sessionKey];
-            const hearingParts = Object.values(inputHearingParts).filter(hearingPart => hearingPart.session === sessionData.id);
+            const hearingParts = Object.values(inputHearingParts).filter(hearingPart => hearingPart.sessionId === sessionData.id);
             const allocated = calculateAllocated(hearingParts);
             const sessionType = (sessionTypes[sessionData.sessionTypeCode] === undefined) ?
                 {code: 'N/A', description: 'N/A'} as SessionType :

--- a/src/app/sessions/services/sessions-filter-service.ts
+++ b/src/app/sessions/services/sessions-filter-service.ts
@@ -47,7 +47,7 @@ export class SessionsFilterService {
 
     filterUnlistedHearingParts(data: HearingPartViewModel[]): HearingPartViewModel[] {
         return data.filter(h => {
-            return h.session === undefined || h.session === '' || h.session === null
+            return h.sessionId === undefined || h.sessionId === '' || h.sessionId === null
         });
     }
 }

--- a/src/app/sessions/services/sessions-statistics-service.spec.ts
+++ b/src/app/sessions/services/sessions-statistics-service.spec.ts
@@ -10,7 +10,7 @@ let session: SessionViewModel;
 function createHearingPart(duration: moment.Duration = moment.duration('PT20M')) {
     return {
         id: undefined,
-        session: undefined,
+        sessionId: undefined,
         caseNumber: undefined,
         caseTitle: undefined,
         caseType: undefined,
@@ -86,7 +86,7 @@ describe('SessionsStatisticsService', () => {
                 person: undefined,
                 sessionType: undefined,
                 caseType: undefined,
-                hearingParts: [] as [HearingPartViewModel],
+                hearingParts: [],
                 jurisdiction: undefined,
                 version: undefined,
                 allocated: undefined,


### PR DESCRIPTION
Hey, in events I've introduced new models for creating, updating and returning hearing part.
The same approach I've applied on frontend side. 3 new models has been added to reflect required changes. This required to update HearingParty and HearingPartViewModel as well. 
This changed tided up a bit ListingCreate. I have removed duplicated userTransactionId

Also with these changes, I normalized out properties name from
session -> sessionId
caseType -> caseTypeCode
hearingType -> hearingTypeCode

these changed requires following PRs
https://github.com/hmcts/snl-events/pull/130
https://github.com/hmcts/snl-rules/pull/69