### PR TITLE
[PREVIEW] Bugfix/sl 1901/ie11 planner

### DIFF
--- a/src/app/common/ng-fullcalendar/ng-full-calendar.component.ts
+++ b/src/app/common/ng-fullcalendar/ng-full-calendar.component.ts
@@ -94,7 +94,6 @@ export class NgFullCalendarComponent implements AfterViewInit {
                 }
             });
         }, );
-
     }
 
     updateEventsBeforeResize() {
@@ -103,6 +102,7 @@ export class NgFullCalendarComponent implements AfterViewInit {
         this.eventsModel = events;
         this.eventsModelChange.next(events);
     }
+
     updaterOptions() {
         let elem = document.getElementsByTagName('ng-fullcalendar');
         this.options.eventDrop = (event, duration, revertFunc) => {
@@ -129,13 +129,14 @@ export class NgFullCalendarComponent implements AfterViewInit {
         };
         this.options.eventRender = function (event, element, view) {
             let detail: RenderEventModel = { event: event, element: element, view: view };
-          let widgetEvent = new CustomEvent('eventRender', {
+            let widgetEvent = new CustomEvent('eventRender', {
                 bubbles: true,
                 detail: detail
             });
             for (let i = 0; i < elem.length; i++) {
                 elem[i].dispatchEvent(widgetEvent);
             }
+            element.css('overflow-y', 'visible');
         };
         this.options.eventClick = (event) => {
             let detail: UpdateEventModel = { event: event, duration: null, revertFunc: null };
@@ -231,15 +232,14 @@ export class NgFullCalendarComponent implements AfterViewInit {
             }
         };
         this.options.drop = (date: any, jsEvent: Event, ui: any, resourceId?: any) => {
-           let detail = { date: date, jsEvent: jsEvent, ui: ui, resourceId: resourceId };
-           const widgetEvent = new CustomEvent('drop', {
+            let detail = { date: date, jsEvent: jsEvent, ui: ui, resourceId: resourceId };
+            const widgetEvent = new CustomEvent('drop', {
                 bubbles: true,
                 detail: detail
             });
             // probably need to add an event - not handled!
-           elem[0].dispatchEvent(widgetEvent);
+            elem[0].dispatchEvent(widgetEvent);
         };
-
         this.options.eventMouseover = (event: any, jsEvent: Event, view: any) => {
             let detail = { event: event, jsEvent: jsEvent, view: view };
             const widgetEvent = new CustomEvent('eventMouseOver', {
@@ -289,5 +289,4 @@ export class NgFullCalendarComponent implements AfterViewInit {
             $(this.element.nativeElement).fullCalendar('rerenderEvents');
         }
     }
-
 }

--- a/src/app/common/ng-fullcalendar/ng-full-calendar.component.ts
+++ b/src/app/common/ng-fullcalendar/ng-full-calendar.component.ts
@@ -136,7 +136,6 @@ export class NgFullCalendarComponent implements AfterViewInit {
             for (let i = 0; i < elem.length; i++) {
                 elem[i].dispatchEvent(widgetEvent);
             }
-            element.css('overflow-y', 'visible');
         };
         this.options.eventClick = (event) => {
             let detail: UpdateEventModel = { event: event, duration: null, revertFunc: null };

--- a/src/app/core/callendar/components/calendar.component.ts
+++ b/src/app/core/callendar/components/calendar.component.ts
@@ -111,7 +111,7 @@ export class CalendarComponent implements OnInit {
 
     public eventRender(event) {
         // TODO extract this method somewhere outside of component, or at least data related parts
-        let el = event.detail.element.css('overflow-y', 'auto');
+        let el = event.detail.element;
         event.detail.event.hearingParts.forEach(hearing => {
             el.append('</br>');
             el.append(hearing.caseTitle);


### PR DESCRIPTION
This could not be fixed by adding new SCSS - the styles were not overwriting the fullcalendar plugin's classes.

Instead, when rendering the element via the plugin, the 'overflow-y' attribute is being set to 'visible' on each event; This attribute was previously 'auto' in ie11.