### PR TITLE
Feature/sl 1969/duration and sessions hearing details

### DIFF
--- a/e2e/models/create-listing-request-body.ts
+++ b/e2e/models/create-listing-request-body.ts
@@ -8,4 +8,5 @@ export interface CreateListingRequestBody {
     priority: string;
     userTransactionId: string;
     numberOfSessions: number;
+    isMultiSession: boolean;
 }

--- a/e2e/models/listing-creation-form.ts
+++ b/e2e/models/listing-creation-form.ts
@@ -11,4 +11,5 @@ export interface ListingCreationForm {
   numberOfSessions: number;
   fromDate: string;
   endDate: string;
+  isMultiSession: boolean;
 }

--- a/e2e/specs/amend-listing-request.e2e-spec.ts
+++ b/e2e/specs/amend-listing-request.e2e-spec.ts
@@ -44,7 +44,7 @@ const displayedListingRequestData = {
 
 const listingRequestCreate: CreateListingRequestBody = {
     id, caseNumber, caseTitle, priority, duration, userTransactionId, caseTypeCode: 'small-claims',  hearingTypeCode: 'trial',
-    numberOfSessions: 1
+    numberOfSessions: 1, isMultiSession: false
 };
 
 describe('Amend Listing Request', () => {
@@ -78,6 +78,7 @@ describe('Amend Listing Request', () => {
         durationMinutes: otherDuration,
         durationDays: null,
         numberOfSessions: 1,
+        isMultiSession: false,
         fromDate: todayDate,
         endDate: tomorrowDate
       };

--- a/e2e/specs/create-listing-request.e2e-spec.ts
+++ b/e2e/specs/create-listing-request.e2e-spec.ts
@@ -26,6 +26,7 @@ const formValues: ListingCreationForm = {
   durationMinutes: 60,
   durationDays: null,
   numberOfSessions: 1,
+  isMultiSession: false,
   fromDate: tomorrowString,
   endDate: tomorrowString
 };
@@ -82,7 +83,8 @@ describe('Create Listing Request', () => {
               ...formValues,
               durationMinutes: 0,
               durationDays: 3,
-              numberOfSessions: 5
+              numberOfSessions: 5,
+              isMultiSession: true
           } as ListingCreationForm;
           await listingCreationPage.createListingRequest(multiSessionFormValues)
           expect(await transactionDialogPage.isActionCreationSummaryDisplayed()).toBeTruthy()

--- a/e2e/specs/session.e2e-spec.ts
+++ b/e2e/specs/session.e2e-spec.ts
@@ -40,6 +40,7 @@ const listingCreationForm: ListingCreationForm = {
     durationMinutes: duration,
     durationDays: null,
     numberOfSessions: 1,
+    isMultiSession: false,
     fromDate: todayDate,
     endDate: tomorrowDate
 };

--- a/e2e/specs/view-hearing.e2e-spec.ts
+++ b/e2e/specs/view-hearing.e2e-spec.ts
@@ -29,7 +29,8 @@ const createListingRequestWithCaseNumberAndId = async function (givenCaseNumber:
             duration: 'PT30M',
             priority: Priority.High,
             userTransactionId: uuid(),
-            numberOfSessions: 1
+            numberOfSessions: 1,
+            isMultiSession: false
         } as CreateListingRequestBody
     );
 };

--- a/src/app/hearing-part/actions/hearing.action.spec.ts
+++ b/src/app/hearing-part/actions/hearing.action.spec.ts
@@ -106,7 +106,8 @@ describe('HearingAction', () => {
                     communicationFacilitator: '123',
                     userTransactionId: '123',
                     version: 1,
-                    numberOfSessions: 1
+                    numberOfSessions: 1,
+                    isMultiSession: false
                 },
                 notes: []
             };
@@ -134,7 +135,8 @@ describe('HearingAction', () => {
                 reservedJudgeId: 'judge',
                 communicationFacilitator: 'translator',
                 userTransactionId: '123',
-                numberOfSessions: 1
+                numberOfSessions: 1,
+                isMultiSession: false
             };
             const action = new CreateListingRequest(payload);
 

--- a/src/app/hearing-part/components/draggable-hearing-part/draggable-hearing-part.component.html
+++ b/src/app/hearing-part/components/draggable-hearing-part/draggable-hearing-part.component.html
@@ -4,5 +4,5 @@
   <span fxFlex="25%">{{hearingPart.hearingType.description}}</span>
   <span fxFlex="10%">{{hearingPart.start | appDateTimeToHHmm}}</span>
   <span fxFlex="10%">{{hearingPart.duration | appDurationFormat}}</span>
-  <span fxFlex="5%" *ngIf="hearingPart.belongsToMultiSession">*</span>
+  <span fxFlex="5%" *ngIf="hearingPart.isMultiSession">*</span>
 </div>

--- a/src/app/hearing-part/components/hearing-parts-preview/hearing-parts-preview.component.html
+++ b/src/app/hearing-part/components/hearing-parts-preview/hearing-parts-preview.component.html
@@ -42,7 +42,7 @@ matSortDirection="desc">
 
   <ng-container matColumnDef="requiredSessions">
     <mat-header-cell *matHeaderCellDef mat-sort-header> Required sessions </mat-header-cell>
-    <mat-cell *matCellDef="let element"> {{element.numberOfSessionsNeeded}} </mat-cell>
+    <mat-cell *matCellDef="let element"> {{element.numberOfSessions}} </mat-cell>
   </ng-container>
 
   <ng-container matColumnDef="hearingType">

--- a/src/app/hearing-part/components/hearing-parts-preview/hearing-parts-preview.component.spec.ts
+++ b/src/app/hearing-part/components/hearing-parts-preview/hearing-parts-preview.component.spec.ts
@@ -154,7 +154,8 @@ describe('HearingPartPreviewComponent', () => {
             communicationFacilitator: 'cf',
             notes: [],
             isListed: false,
-            numberOfSessions: 1
+            numberOfSessions: 1,
+            isMultiSession: false
         } as HearingViewmodel;
 
         const displayedColumnsExpectedValues = [
@@ -211,6 +212,7 @@ function generateHearings(id: string): HearingViewmodel {
         communicationFacilitator: null,
         notes: [],
         isListed: false,
-        numberOfSessions: 1
+        numberOfSessions: 1,
+        isMultiSession: false
     }
 };

--- a/src/app/hearing-part/components/hearing-parts-preview/hearing-parts-preview.component.spec.ts
+++ b/src/app/hearing-part/components/hearing-parts-preview/hearing-parts-preview.component.spec.ts
@@ -154,7 +154,7 @@ describe('HearingPartPreviewComponent', () => {
             communicationFacilitator: 'cf',
             notes: [],
             isListed: false,
-            numberOfSessionsNeeded: 0
+            numberOfSessions: 1
         } as HearingViewmodel;
 
         const displayedColumnsExpectedValues = [
@@ -166,7 +166,7 @@ describe('HearingPartPreviewComponent', () => {
             { columnName: 'communicationFacilitator', expected: sampleHearing.communicationFacilitator },
             { columnName: 'priority', expected: priorityValue(sampleHearing.priority) },
             { columnName: 'reservedJudge', expected: sampleHearing.reservedJudge.name },
-            { columnName: 'requiredSessions', expected: sampleHearing.numberOfSessionsNeeded },
+            { columnName: 'requiredSessions', expected: sampleHearing.numberOfSessions },
             { columnName: 'notes', expected: 'No' },
             { columnName: 'scheduleStart', expected: sampleHearing.scheduleStart.unix() },
             { columnName: 'scheduleEnd', expected: sampleHearing.scheduleEnd.unix() },
@@ -211,6 +211,6 @@ function generateHearings(id: string): HearingViewmodel {
         communicationFacilitator: null,
         notes: [],
         isListed: false,
-        numberOfSessionsNeeded: 0
+        numberOfSessions: 1
     }
 };

--- a/src/app/hearing-part/components/hearing-parts-preview/hearing-parts-preview.component.ts
+++ b/src/app/hearing-part/components/hearing-parts-preview/hearing-parts-preview.component.ts
@@ -66,7 +66,7 @@ export class HearingPartsPreviewComponent implements OnInit, OnChanges {
                 case 'duration':
                     return moment.duration(item[property]).asMilliseconds();
                 case 'requiredSessions':
-                    return item['numberOfSessionsNeeded'];
+                    return item['numberOfSessions'];
 
                 case 'reservedJudge':
                     return this.getPropertyMemberOrNull(item, property, 'name');

--- a/src/app/hearing-part/components/listing-create/listing-create.component.spec.ts
+++ b/src/app/hearing-part/components/listing-create/listing-create.component.spec.ts
@@ -77,7 +77,8 @@ const listingCreate = {
         reservedJudgeId: undefined,
         communicationFacilitator: undefined,
         userTransactionId: 'uti',
-        numberOfSessions: 1
+        numberOfSessions: 1,
+        isMultiSession: false
     },
     notes: [],
     userTransactionId: undefined
@@ -213,6 +214,7 @@ describe('ListingCreateComponent', () => {
             const threeDaysDuration = moment.duration(3, 'days');
             component.listing.hearing.duration = threeDaysDuration;
             component.listing.hearing.numberOfSessions = 5;
+            component.listing.hearing.isMultiSession = true;
             component.chosenListingType = ListingTypeTab.Multi;
 
             component.save();
@@ -233,6 +235,7 @@ describe('ListingCreateComponent', () => {
             expect(createdListing.scheduleEnd).toEqual(now);
             expect(createdListing.duration).toEqual(moment.duration(threeDaysDuration.asMilliseconds()));
             expect(createdListing.numberOfSessions).toEqual(5);
+            expect(createdListing.isMultiSession).toEqual(true);
         });
 
         it('should dispatch action with 1 as a numberOfSessions and max minutes for a day, ' +

--- a/src/app/hearing-part/components/listing-create/listing-create.component.ts
+++ b/src/app/hearing-part/components/listing-create/listing-create.component.ts
@@ -217,7 +217,8 @@ export class ListingCreateComponent implements OnInit {
                 reservedJudgeId: undefined,
                 communicationFacilitator: undefined,
                 userTransactionId: undefined,
-                numberOfSessions: 1
+                numberOfSessions: 1,
+                isMultiSession: false,
             },
             notes: []
         };
@@ -289,6 +290,7 @@ export class ListingCreateComponent implements OnInit {
                 this.listing.hearing.duration = moment.duration(
                     moment.duration(this.asDaysPipe.transform(this.listing.hearing.duration), 'days').asMinutes()
                     , 'minutes');
+                this.listing.hearing.isMultiSession = true;
                 break;
             case ListingTypeTab.Single:
             default:
@@ -296,6 +298,7 @@ export class ListingCreateComponent implements OnInit {
                     this.listing.hearing.duration = moment.duration(24 * 60 - 1, 'minutes');
                 }
                 this.listing.hearing.numberOfSessions = 1;
+                this.listing.hearing.isMultiSession = false;
                 break;
         }
     }

--- a/src/app/hearing-part/models/create-hearing-request.ts
+++ b/src/app/hearing-part/models/create-hearing-request.ts
@@ -15,4 +15,5 @@ export interface CreateHearingRequest {
     communicationFacilitator: string;
     userTransactionId: string;
     numberOfSessions: number;
+    isMultiSession: boolean;
 }

--- a/src/app/hearing-part/models/hearing-part.viewmodel.ts
+++ b/src/app/hearing-part/models/hearing-part.viewmodel.ts
@@ -43,6 +43,6 @@ export function mapToUpdateHearingRequest(hvm: HearingViewmodel): UpdateHearingR
         reservedJudgeId: hvm.reservedJudgeId,
         communicationFacilitator: hvm.communicationFacilitator,
         userTransactionId: undefined,
-        numberOfSessions: undefined
+        numberOfSessions: hvm.numberOfSessions
     }
 }

--- a/src/app/hearing-part/models/hearing-part.viewmodel.ts
+++ b/src/app/hearing-part/models/hearing-part.viewmodel.ts
@@ -43,6 +43,7 @@ export function mapToUpdateHearingRequest(hvm: HearingViewmodel): UpdateHearingR
         reservedJudgeId: hvm.reservedJudgeId,
         communicationFacilitator: hvm.communicationFacilitator,
         userTransactionId: undefined,
-        numberOfSessions: hvm.numberOfSessions
+        numberOfSessions: hvm.numberOfSessions,
+        isMultiSession: hvm.isMultiSession
     }
 }

--- a/src/app/hearing-part/models/hearing-part.viewmodel.ts
+++ b/src/app/hearing-part/models/hearing-part.viewmodel.ts
@@ -25,7 +25,7 @@ export interface HearingPartViewModel {
     reservedJudgeId: string;
     hearingId: string;
     start: moment.Moment;
-    belongsToMultiSession: boolean;
+    isMultiSession: boolean;
 }
 
 export function mapToUpdateHearingRequest(hvm: HearingViewmodel): UpdateHearingRequest {

--- a/src/app/hearing-part/models/hearing.ts
+++ b/src/app/hearing-part/models/hearing.ts
@@ -13,4 +13,5 @@ export interface Hearing {
     deleted: boolean;
     version: number;
     numberOfSessions: number;
+    isMultiSession: boolean;
 }

--- a/src/app/hearing-part/models/hearing.ts
+++ b/src/app/hearing-part/models/hearing.ts
@@ -12,5 +12,5 @@ export interface Hearing {
     communicationFacilitator: string;
     deleted: boolean;
     version: number;
-    numberOfSessionsNeeded: number;
+    numberOfSessions: number;
 }

--- a/src/app/hearing-part/models/hearing.viewmodel.ts
+++ b/src/app/hearing-part/models/hearing.viewmodel.ts
@@ -21,5 +21,5 @@ export interface HearingViewmodel {
     reservedJudge: Judge;
     reservedJudgeId: string;
     isListed: boolean;
-    numberOfSessionsNeeded: number;
+    numberOfSessions: number;
 }

--- a/src/app/hearing-part/models/hearing.viewmodel.ts
+++ b/src/app/hearing-part/models/hearing.viewmodel.ts
@@ -22,4 +22,5 @@ export interface HearingViewmodel {
     reservedJudgeId: string;
     isListed: boolean;
     numberOfSessions: number;
+    isMultiSession: boolean;
 }

--- a/src/app/hearing-part/reducers/index.ts
+++ b/src/app/hearing-part/reducers/index.ts
@@ -91,7 +91,7 @@ export const getFullHearingParts = createSelector(getAllHearingParts, getNotes, 
                 hearingId: hearing.id,
                 notes: sortedNotes,
                 start: moment(start),
-                belongsToMultiSession: hearing.numberOfSessions > 1
+                isMultiSession: hearing.isMultiSession
             };
         });
         return finalHearingParts;

--- a/src/app/hearing-part/reducers/index.ts
+++ b/src/app/hearing-part/reducers/index.ts
@@ -91,7 +91,7 @@ export const getFullHearingParts = createSelector(getAllHearingParts, getNotes, 
                 hearingId: hearing.id,
                 notes: sortedNotes,
                 start: moment(start),
-                belongsToMultiSession: hearing.numberOfSessionsNeeded > 1
+                belongsToMultiSession: hearing.numberOfSessions > 1
             };
         });
         return finalHearingParts;
@@ -127,7 +127,7 @@ export const getFullHearings = createSelector(getAllHearingParts, getHearingsEnt
                 reservedJudge: judges[h.reservedJudgeId],
                 notes: sortedNotes,
                 isListed: !unlisted,
-                numberOfSessionsNeeded: h.numberOfSessionsNeeded
+                numberOfSessions: h.numberOfSessions
             }
         });
 

--- a/src/app/hearing-part/reducers/index.ts
+++ b/src/app/hearing-part/reducers/index.ts
@@ -127,7 +127,8 @@ export const getFullHearings = createSelector(getAllHearingParts, getHearingsEnt
                 reservedJudge: judges[h.reservedJudgeId],
                 notes: sortedNotes,
                 isListed: !unlisted,
-                numberOfSessions: h.numberOfSessions
+                numberOfSessions: h.numberOfSessions,
+                isMultiSession: h.isMultiSession
             }
         });
 

--- a/src/app/hearing-part/services/hearing-part-service.spec.ts
+++ b/src/app/hearing-part/services/hearing-part-service.spec.ts
@@ -123,7 +123,8 @@ const createHearingPartRequest: CreateHearingRequest = {
     communicationFacilitator: null,
     priority: null,
     userTransactionId: uuid(),
-    numberOfSessions: 1
+    numberOfSessions: 1,
+    isMultiSession: false
 };
 
 const updateHearingPartRequest: UpdateHearingRequest = {

--- a/src/app/hearing/components/view-hearing/view-hearing.component.html
+++ b/src/app/hearing/components/view-hearing/view-hearing.component.html
@@ -21,11 +21,11 @@
     </div>
 
     <div class="tile">
-      <strong>Estimated duration <ng-container *ngIf="hearing.isMultiSession; then days; else minutes"></ng-container>
-        <ng-template #days>(days)</ng-template>
-        <ng-template #minutes>(HH:mm)</ng-template>
+      <strong>Estimated duration
       </strong><br>
-      {{formatDuration(hearing.duration)}}
+      {{formatDuration(hearing.duration)}}<ng-container *ngIf="hearing.isMultiSession; then days; else minutes"></ng-container>
+      <ng-template #days>ay(s)</ng-template>
+      <ng-template #minutes> (Hours / Minutes)</ng-template>
     </div>
 
     <div class="tile">

--- a/src/app/hearing/components/view-hearing/view-hearing.component.html
+++ b/src/app/hearing/components/view-hearing/view-hearing.component.html
@@ -21,8 +21,16 @@
     </div>
 
     <div class="tile">
-      <strong>Estimated duration</strong><br>
+      <strong>Estimated duration <ng-container *ngIf="hearing.numberOfSessions > 1; then days; else minutes"></ng-container>
+        <ng-template #days>(days)</ng-template>
+        <ng-template #minutes>(HH:mm)</ng-template>
+      </strong><br>
       {{formatDuration(hearing.duration)}}
+    </div>
+
+    <div class="tile">
+      <strong>Required Sessions</strong><br>
+      {{(hearing.numberOfSessions)}}
     </div>
 
     <div class="tile">

--- a/src/app/hearing/components/view-hearing/view-hearing.component.html
+++ b/src/app/hearing/components/view-hearing/view-hearing.component.html
@@ -39,9 +39,6 @@
     </div>
 
     <div class="tile">
-    </div>
-
-    <div class="tile">
       <strong>Reserved for</strong><br>
       {{hearing.reservedToJudge}}
     </div>
@@ -62,6 +59,9 @@
     <div class="tile">
       <strong>Facility requirements</strong><br>
       {{hearing.facilityRequirements}}
+    </div>
+
+    <div class="tile">
     </div>
 
     <div class="clear"></div>

--- a/src/app/hearing/components/view-hearing/view-hearing.component.html
+++ b/src/app/hearing/components/view-hearing/view-hearing.component.html
@@ -21,7 +21,7 @@
     </div>
 
     <div class="tile">
-      <strong>Estimated duration <ng-container *ngIf="hearing.numberOfSessions > 1; then days; else minutes"></ng-container>
+      <strong>Estimated duration <ng-container *ngIf="hearing.isMultiSession; then days; else minutes"></ng-container>
         <ng-template #days>(days)</ng-template>
         <ng-template #minutes>(HH:mm)</ng-template>
       </strong><br>

--- a/src/app/hearing/components/view-hearing/view-hearing.component.spec.ts
+++ b/src/app/hearing/components/view-hearing/view-hearing.component.spec.ts
@@ -108,8 +108,8 @@ describe('ViewHearingComponent', () => {
     expect(component.getListBetween()).toEqual('');
   });
 
-  it('formatDuration formats duration with minutes', () => {
+  it('formatDuration formats duration to HHmm', () => {
     const duration = component.formatDuration('PT30M');
-    expect(duration).toEqual('30 minutes');
+    expect(duration).toEqual('00:30');
   });
 });

--- a/src/app/hearing/components/view-hearing/view-hearing.component.ts
+++ b/src/app/hearing/components/view-hearing/view-hearing.component.ts
@@ -4,6 +4,7 @@ import { Hearing, Session } from '../../models/hearing';
 import * as moment from 'moment';
 import { ActivatedRoute } from '@angular/router';
 import { Location } from '@angular/common';
+import { formatDuration} from '../../../utils/date-utils';
 
 @Component({
   selector: 'app-view-hearing',
@@ -32,9 +33,7 @@ export class ViewHearingComponent implements OnInit {
   }
 
   formatDuration(duration: string): string {
-    const minutes = moment.duration(duration).asMinutes();
-
-    return Math.ceil(minutes) + ' minutes';
+    return formatDuration(moment.duration(duration))
   }
 
   getListBetween() {

--- a/src/app/hearing/models/hearing.ts
+++ b/src/app/hearing/models/hearing.ts
@@ -32,5 +32,6 @@ export interface Hearing {
   reservedToJudge: string,
   notes: Note[],
   sessions: Session[],
-  numberOfSessions: number
+  numberOfSessions: number,
+  isMultiSession: boolean
 }

--- a/src/app/hearing/models/hearing.ts
+++ b/src/app/hearing/models/hearing.ts
@@ -31,5 +31,6 @@ export interface Hearing {
   facilityRequirements: string,
   reservedToJudge: string,
   notes: Note[],
-  sessions: Session[]
+  sessions: Session[],
+  numberOfSessions: number
 }

--- a/src/app/sessions/components/details-dialog/details-dialog.component.ts
+++ b/src/app/sessions/components/details-dialog/details-dialog.component.ts
@@ -18,6 +18,6 @@ export class DetailsDialogComponent extends DraggableDialog {
     }
 
     displayInformativeLegend(hearingParts: HearingPartViewModel[]) {
-        return hearingParts.find(hp => hp.belongsToMultiSession) !== undefined;
+        return hearingParts.find(hp => hp.isMultiSession) !== undefined;
     }
 }

--- a/src/app/sessions/components/details-dialog/details-dialog.component.ts
+++ b/src/app/sessions/components/details-dialog/details-dialog.component.ts
@@ -18,6 +18,6 @@ export class DetailsDialogComponent extends DraggableDialog {
     }
 
     displayInformativeLegend(hearingParts: HearingPartViewModel[]) {
-        return hearingParts.find(hp => hp.isMultiSession) !== undefined;
+        return hearingParts.find(hp => hp.isMultiSession);
     }
 }

--- a/src/app/sessions/components/sessions-amend-form/sessions-amend-form.component.html
+++ b/src/app/sessions/components/sessions-amend-form/sessions-amend-form.component.html
@@ -39,7 +39,7 @@
         <span>Number of listing requests: <strong>{{amendSessionForm.hearingPartCount}}</strong></span>
       </div>
 
-      <div *ngIf="amendSessionForm.belongsToMultiSession">
+      <div *ngIf="amendSessionForm.isMultiSession">
         <span class="snl-informative-legend">This session contains a multi-session hearing</span>
       </div>
     </form>

--- a/src/app/sessions/containers/sessions-listings-search/sessions-listings-search.component.spec.ts
+++ b/src/app/sessions/containers/sessions-listings-search/sessions-listings-search.component.spec.ts
@@ -101,7 +101,7 @@ const mockedUnlistedHearingPartVM: HearingPartViewModel = {
     notes: [],
     reservedJudge: mockedJudges[0],
     start: moment(nowISOSting),
-    belongsToMultiSession: false
+    isMultiSession: false
 };
 
 const mockedUnlistedHearingVM: HearingViewmodel = {

--- a/src/app/sessions/containers/sessions-listings-search/sessions-listings-search.component.spec.ts
+++ b/src/app/sessions/containers/sessions-listings-search/sessions-listings-search.component.spec.ts
@@ -120,7 +120,8 @@ const mockedUnlistedHearingVM: HearingViewmodel = {
     notes: mockedNotes,
     reservedJudge: mockedJudges[0],
     isListed: false,
-    numberOfSessions: 1
+    numberOfSessions: 1,
+    isMultiSession: false
 }
 
 const mockedHearingResponse: Hearing = {
@@ -137,7 +138,8 @@ const mockedHearingResponse: Hearing = {
     scheduleEnd: nowISOSting,
     scheduleStart: nowISOSting,
     version: 2,
-    numberOfSessions: 1
+    numberOfSessions: 1,
+    isMultiSession: false
 }
 
 // same as unlisted, but with session set to matching id in Session

--- a/src/app/sessions/containers/sessions-listings-search/sessions-listings-search.component.spec.ts
+++ b/src/app/sessions/containers/sessions-listings-search/sessions-listings-search.component.spec.ts
@@ -120,7 +120,7 @@ const mockedUnlistedHearingVM: HearingViewmodel = {
     notes: mockedNotes,
     reservedJudge: mockedJudges[0],
     isListed: false,
-    numberOfSessionsNeeded: 1
+    numberOfSessions: 1
 }
 
 const mockedHearingResponse: Hearing = {
@@ -137,7 +137,7 @@ const mockedHearingResponse: Hearing = {
     scheduleEnd: nowISOSting,
     scheduleStart: nowISOSting,
     version: 2,
-    numberOfSessionsNeeded: 1
+    numberOfSessions: 1
 }
 
 // same as unlisted, but with session set to matching id in Session

--- a/src/app/sessions/containers/sessions-listings-search/sessions-listings-search.component.ts
+++ b/src/app/sessions/containers/sessions-listings-search/sessions-listings-search.component.ts
@@ -60,7 +60,7 @@ export class SessionsListingsSearchComponent implements OnInit {
     sessionTypes$: Observable<SessionType[]>;
     filteredSessions: SessionViewModel[];
     errorMessage: string;
-    numberOfSessionsNeeded = 0;
+    numberOfSessions = 0;
 
     constructor(private readonly store: Store<fromHearingParts.State>,
                 private readonly sessionsFilterService: SessionsFilterService,
@@ -107,7 +107,7 @@ export class SessionsListingsSearchComponent implements OnInit {
 
     selectHearing(hearing: HearingViewmodel) {
         this.selectedHearing = hearing;
-        this.numberOfSessionsNeeded = hearing !== undefined ? hearing.numberOfSessionsNeeded : 0;
+        this.numberOfSessions = hearing !== undefined ? hearing.numberOfSessions : 0;
     }
 
     selectSession(sessions: SessionViewModel[]) {
@@ -140,7 +140,7 @@ export class SessionsListingsSearchComponent implements OnInit {
         if (this.selectedHearing === undefined) {
             this.errorMessage = '';
             return false;
-        } else if (this.numberOfSessionsNeeded === this.selectedSessions.length) {
+        } else if (this.numberOfSessions === this.selectedSessions.length) {
             this.errorMessage = '';
             return this.checkIfOnlyOneJudgeSelected();
         } else {
@@ -178,7 +178,7 @@ export class SessionsListingsSearchComponent implements OnInit {
     }
 
     private checkIfOnlyOneJudgeSelected() {
-        if (this.selectedHearing.numberOfSessionsNeeded === 1) {
+        if (this.selectedHearing.numberOfSessions === 1) {
             this.errorMessage = '';
             return true;
         } else if (!this.selectedSessions.every((val, i, arr) =>

--- a/src/app/sessions/containers/sessions-listings-search/sessions-listings-search.component.ts
+++ b/src/app/sessions/containers/sessions-listings-search/sessions-listings-search.component.ts
@@ -61,6 +61,7 @@ export class SessionsListingsSearchComponent implements OnInit {
     filteredSessions: SessionViewModel[];
     errorMessage: string;
     numberOfSessions = 0;
+    isMultiSession = false;
 
     constructor(private readonly store: Store<fromHearingParts.State>,
                 private readonly sessionsFilterService: SessionsFilterService,
@@ -108,6 +109,7 @@ export class SessionsListingsSearchComponent implements OnInit {
     selectHearing(hearing: HearingViewmodel) {
         this.selectedHearing = hearing;
         this.numberOfSessions = hearing !== undefined ? hearing.numberOfSessions : 0;
+        this.isMultiSession = hearing !== undefined ? hearing.isMultiSession : false;
     }
 
     selectSession(sessions: SessionViewModel[]) {

--- a/src/app/sessions/mappers/amend-session-form-session-amend.ts
+++ b/src/app/sessions/mappers/amend-session-form-session-amend.ts
@@ -25,7 +25,7 @@ export const SessionToAmendSessionForm = (session: SessionViewModel, roomTypes: 
         roomName: roomName,
         roomType: roomType,
         hearingPartCount: hearingPartCount,
-        belongsToMultiSession: session.hearingParts.find(hp => hp.belongsToMultiSession === true) !== undefined
+        isMultiSession: session.hearingParts.find(hp => hp.isMultiSession === true) !== undefined
     } as SessionAmmendForm
 }
 

--- a/src/app/sessions/mappers/amend-session-form-session-amend.ts
+++ b/src/app/sessions/mappers/amend-session-form-session-amend.ts
@@ -25,7 +25,7 @@ export const SessionToAmendSessionForm = (session: SessionViewModel, roomTypes: 
         roomName: roomName,
         roomType: roomType,
         hearingPartCount: hearingPartCount,
-        isMultiSession: session.hearingParts.find(hp => hp.isMultiSession === true) !== undefined
+        isMultiSession: session.hearingParts.find(hp => hp.isMultiSession) !== undefined
     } as SessionAmmendForm
 }
 

--- a/src/app/sessions/models/ammend/session-ammend-form.model.ts
+++ b/src/app/sessions/models/ammend/session-ammend-form.model.ts
@@ -11,5 +11,5 @@ export interface SessionAmmendForm {
     personName: string,
     hearingPartCount: number,
     version: number,
-    belongsToMultiSession: boolean
+    isMultiSession: boolean
 }


### PR DESCRIPTION
Added 'numberOfSessions' and 'isMultiSession' to models.
Replaced the old logic for determining both.
Updated unit + e2e tests to include values for both.

Will append [PREVIEW] when https://github.com/hmcts/snl-events/pull/165 is approved