### PR TITLE
[PREVIEW] SL-2106 Fix for wrong time being set when planning in or out of DST

### DIFF
--- a/src/app/sessions/mappers/amend-session-form-session-amend.ts
+++ b/src/app/sessions/mappers/amend-session-form-session-amend.ts
@@ -30,14 +30,16 @@ export const SessionToAmendSessionForm = (session: SessionViewModel, roomTypes: 
 }
 
 export const AmendSessionFormToSessionAmend = (amendSessionForm: SessionAmmendForm): SessionAmmend => {
-    const sessionTypeCode = amendSessionForm.sessionTypeCode
+    const sessionTypeCode = amendSessionForm.sessionTypeCode;
     const durationInSeconds = Math.floor(amendSessionForm.durationInMinutes.valueOf() * 60)
-    const startTime = moment.utc(moment(amendSessionForm.startTime, 'HH:mm')).format('HH:mm');
+    let startTime = moment(amendSessionForm.startTime, 'HH:mm');
+    startTime = moment.utc(amendSessionForm.startDate.hour(startTime.hour()).minutes(startTime.minute()));
+    const formattedStartTime = startTime.format('HH:mm');
 
     return {
         sessionTypeCode: sessionTypeCode,
         durationInSeconds: durationInSeconds,
-        startTime: startTime,
+        startTime: formattedStartTime,
         id: amendSessionForm.id,
         userTransactionId: undefined,
         version: amendSessionForm.version,


### PR DESCRIPTION
.utc is important, but additionally it's important to use the expected date in potentially another Daylight saving time(DST), that's why there is startDate used as a starting point.

Now when a user enters in winter start time 8:00 it will send to the backend a 6:00 (+2Z) instead of previously 7:00 (+2Z). This 7 was coming from the fact that in winter there is one hour less difference with the UTC and Moment.js was using local browser timezone as a starting point for conversions.

It works for DST to non-DST DST DST and non-DST to non-DST