### PR TITLE
[AKS] SL-2198 Capitalise listing in web pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Scheduling and listing Front-end
+# Scheduling and Listing Front-end
 
 [![Build Status](https://travis-ci.org/hmcts/snl-frontend.svg?branch=master)](https://travis-ci.org/hmcts/snl-frontend)
 

--- a/src/app/core/home/home.component.spec.ts
+++ b/src/app/core/home/home.component.spec.ts
@@ -115,7 +115,7 @@ const navigationItemsForOfficer = [
 
 const serviceName = {
     href: '#',
-    name: 'Scheduling and listing'
+    name: 'Scheduling and Listing'
 };
 
 const exampleOfficer = Object.assign(new User(), officerResponse);
@@ -123,7 +123,7 @@ const exampleOfficer = Object.assign(new User(), officerResponse);
 const exampleJudge = Object.assign(new User(), judgeResponse);
 
 const baseNavigation = {
-    label: 'Scheduling and listing',
+    label: 'Scheduling and Listing',
     items: [
         {
             href: null,

--- a/src/app/core/home/home.component.ts
+++ b/src/app/core/home/home.component.ts
@@ -45,7 +45,7 @@ export class HomeComponent implements OnInit {
     this.items = this.buildNavigationItems();
 
     this.navigation = {
-      label: 'Scheduling and listing',
+      label: 'Scheduling and Listing',
       items: [
         {
           href: null,
@@ -60,7 +60,7 @@ export class HomeComponent implements OnInit {
 
     this.serviceName = {
       href: '#',
-      name: 'Scheduling and listing'
+      name: 'Scheduling and Listing'
     }
   }
 


### PR DESCRIPTION
The title of the app, and any label or text with it, should be
"Scheduling and Listing" instead of "Scheduling and listing".